### PR TITLE
[feat] 메인뷰 UI 구현

### DIFF
--- a/PokeDex/PokeDex.xcodeproj/project.pbxproj
+++ b/PokeDex/PokeDex.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		AA75C7202D1D6D95009B2A9D /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C71F2D1D6D95009B2A9D /* MainViewModel.swift */; };
 		AA75C7222D1E3252009B2A9D /* PokemonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7212D1E3252009B2A9D /* PokemonCell.swift */; };
 		AA75C7242D1E3496009B2A9D /* PokemonCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */; };
+		AA75C7262D1E3D26009B2A9D /* PokeDexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 		AA75C71F2D1D6D95009B2A9D /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		AA75C7212D1E3252009B2A9D /* PokemonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonCell.swift; sourceTree = "<group>"; };
 		AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonCollectionView.swift; sourceTree = "<group>"; };
+		AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokeDexView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +92,7 @@
 				AA75C7002D1D1A9C009B2A9D /* MainViewController.swift */,
 				AA75C7212D1E3252009B2A9D /* PokemonCell.swift */,
 				AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */,
+				AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -196,6 +199,7 @@
 				AA75C7172D1D6128009B2A9D /* PokemonDataModel.swift in Sources */,
 				AA75C7192D1D635B009B2A9D /* PokemonDetailDataModel.swift in Sources */,
 				AA75C7032D1D1A9C009B2A9D /* AppDelegate.swift in Sources */,
+				AA75C7262D1E3D26009B2A9D /* PokeDexView.swift in Sources */,
 				AA75C7042D1D1A9C009B2A9D /* MainViewController.swift in Sources */,
 				AA75C7052D1D1A9C009B2A9D /* SceneDelegate.swift in Sources */,
 				AA75C7152D1D4FA9009B2A9D /* NetworkError.swift in Sources */,

--- a/PokeDex/PokeDex.xcodeproj/project.pbxproj
+++ b/PokeDex/PokeDex.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		AA75C7192D1D635B009B2A9D /* PokemonDetailDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7182D1D635B009B2A9D /* PokemonDetailDataModel.swift */; };
 		AA75C7202D1D6D95009B2A9D /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C71F2D1D6D95009B2A9D /* MainViewModel.swift */; };
 		AA75C7222D1E3252009B2A9D /* PokemonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7212D1E3252009B2A9D /* PokemonCell.swift */; };
+		AA75C7242D1E3496009B2A9D /* PokemonCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		AA75C7182D1D635B009B2A9D /* PokemonDetailDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonDetailDataModel.swift; sourceTree = "<group>"; };
 		AA75C71F2D1D6D95009B2A9D /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		AA75C7212D1E3252009B2A9D /* PokemonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonCell.swift; sourceTree = "<group>"; };
+		AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonCollectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +89,7 @@
 			children = (
 				AA75C7002D1D1A9C009B2A9D /* MainViewController.swift */,
 				AA75C7212D1E3252009B2A9D /* PokemonCell.swift */,
+				AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -197,6 +200,7 @@
 				AA75C7052D1D1A9C009B2A9D /* SceneDelegate.swift in Sources */,
 				AA75C7152D1D4FA9009B2A9D /* NetworkError.swift in Sources */,
 				AA75C7202D1D6D95009B2A9D /* MainViewModel.swift in Sources */,
+				AA75C7242D1E3496009B2A9D /* PokemonCollectionView.swift in Sources */,
 				AA75C7222D1E3252009B2A9D /* PokemonCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PokeDex/PokeDex.xcodeproj/project.pbxproj
+++ b/PokeDex/PokeDex.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		AA75C7242D1E3496009B2A9D /* PokemonCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */; };
 		AA75C7262D1E3D26009B2A9D /* PokeDexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */; };
 		AA75C7282D1E7244009B2A9D /* PokemonServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7272D1E7244009B2A9D /* PokemonServiceProtocol.swift */; };
+		AA75C72A2D1E9E39009B2A9D /* URLManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7292D1E9E39009B2A9D /* URLManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +43,7 @@
 		AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonCollectionView.swift; sourceTree = "<group>"; };
 		AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokeDexView.swift; sourceTree = "<group>"; };
 		AA75C7272D1E7244009B2A9D /* PokemonServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonServiceProtocol.swift; sourceTree = "<group>"; };
+		AA75C7292D1E9E39009B2A9D /* URLManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,6 +117,7 @@
 				AA75C7142D1D4FA9009B2A9D /* NetworkError.swift */,
 				AA75C7162D1D6128009B2A9D /* PokemonDataModel.swift */,
 				AA75C7182D1D635B009B2A9D /* PokemonDetailDataModel.swift */,
+				AA75C7292D1E9E39009B2A9D /* URLManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -201,6 +204,7 @@
 				AA75C7132D1D4D62009B2A9D /* NetworkManager.swift in Sources */,
 				AA75C7172D1D6128009B2A9D /* PokemonDataModel.swift in Sources */,
 				AA75C7282D1E7244009B2A9D /* PokemonServiceProtocol.swift in Sources */,
+				AA75C72A2D1E9E39009B2A9D /* URLManager.swift in Sources */,
 				AA75C7192D1D635B009B2A9D /* PokemonDetailDataModel.swift in Sources */,
 				AA75C7032D1D1A9C009B2A9D /* AppDelegate.swift in Sources */,
 				AA75C7262D1E3D26009B2A9D /* PokeDexView.swift in Sources */,

--- a/PokeDex/PokeDex.xcodeproj/project.pbxproj
+++ b/PokeDex/PokeDex.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		AA75C7172D1D6128009B2A9D /* PokemonDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7162D1D6128009B2A9D /* PokemonDataModel.swift */; };
 		AA75C7192D1D635B009B2A9D /* PokemonDetailDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7182D1D635B009B2A9D /* PokemonDetailDataModel.swift */; };
 		AA75C7202D1D6D95009B2A9D /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C71F2D1D6D95009B2A9D /* MainViewModel.swift */; };
+		AA75C7222D1E3252009B2A9D /* PokemonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7212D1E3252009B2A9D /* PokemonCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		AA75C7162D1D6128009B2A9D /* PokemonDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonDataModel.swift; sourceTree = "<group>"; };
 		AA75C7182D1D635B009B2A9D /* PokemonDetailDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonDetailDataModel.swift; sourceTree = "<group>"; };
 		AA75C71F2D1D6D95009B2A9D /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
+		AA75C7212D1E3252009B2A9D /* PokemonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,6 +86,7 @@
 			isa = PBXGroup;
 			children = (
 				AA75C7002D1D1A9C009B2A9D /* MainViewController.swift */,
+				AA75C7212D1E3252009B2A9D /* PokemonCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -194,6 +197,7 @@
 				AA75C7052D1D1A9C009B2A9D /* SceneDelegate.swift in Sources */,
 				AA75C7152D1D4FA9009B2A9D /* NetworkError.swift in Sources */,
 				AA75C7202D1D6D95009B2A9D /* MainViewModel.swift in Sources */,
+				AA75C7222D1E3252009B2A9D /* PokemonCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PokeDex/PokeDex.xcodeproj/project.pbxproj
+++ b/PokeDex/PokeDex.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		AA75C7222D1E3252009B2A9D /* PokemonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7212D1E3252009B2A9D /* PokemonCell.swift */; };
 		AA75C7242D1E3496009B2A9D /* PokemonCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */; };
 		AA75C7262D1E3D26009B2A9D /* PokeDexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */; };
+		AA75C7282D1E7244009B2A9D /* PokemonServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7272D1E7244009B2A9D /* PokemonServiceProtocol.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +41,7 @@
 		AA75C7212D1E3252009B2A9D /* PokemonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonCell.swift; sourceTree = "<group>"; };
 		AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonCollectionView.swift; sourceTree = "<group>"; };
 		AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokeDexView.swift; sourceTree = "<group>"; };
+		AA75C7272D1E7244009B2A9D /* PokemonServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonServiceProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,6 +103,7 @@
 			isa = PBXGroup;
 			children = (
 				AA75C71F2D1D6D95009B2A9D /* MainViewModel.swift */,
+				AA75C7272D1E7244009B2A9D /* PokemonServiceProtocol.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -197,6 +200,7 @@
 			files = (
 				AA75C7132D1D4D62009B2A9D /* NetworkManager.swift in Sources */,
 				AA75C7172D1D6128009B2A9D /* PokemonDataModel.swift in Sources */,
+				AA75C7282D1E7244009B2A9D /* PokemonServiceProtocol.swift in Sources */,
 				AA75C7192D1D635B009B2A9D /* PokemonDetailDataModel.swift in Sources */,
 				AA75C7032D1D1A9C009B2A9D /* AppDelegate.swift in Sources */,
 				AA75C7262D1E3D26009B2A9D /* PokeDexView.swift in Sources */,

--- a/PokeDex/PokeDex/Model/NetworkManager.swift
+++ b/PokeDex/PokeDex/Model/NetworkManager.swift
@@ -5,7 +5,7 @@
 //  Created by 장상경 on 12/26/24.
 //
 
-import Foundation
+import UIKit
 import RxSwift
 
 final class NetworkManager {
@@ -43,5 +43,26 @@ final class NetworkManager {
             
             return Disposables.create()
         }
+    }
+    
+    func fetchImage(id: Int) -> UIImage? {
+        var resultImage: UIImage?
+        guard let url = URL(string: URLManager.pokemonImage(id: id).sendURL) else { return nil }
+        
+        DispatchQueue.global().sync {
+            guard let imageData = try? Data(contentsOf: url) else {
+                resultImage = nil
+                return
+            }
+            
+            guard let image = UIImage(data: imageData) else {
+                resultImage = nil
+                return
+            }
+            
+            resultImage = image
+        }
+        
+        return resultImage
     }
 }

--- a/PokeDex/PokeDex/Model/URLManager.swift
+++ b/PokeDex/PokeDex/Model/URLManager.swift
@@ -11,7 +11,7 @@ enum URLManager {
     case pokemonData(limit: Int, offset: Int)
     case pokemonImage(id: Int)
     
-    func sendURL() -> String {
+    var sendURL: String {
         switch self {
         case .pokemonData(limit: let limit, offset: let offset):
             return "https://pokeapi.co/api/v2/pokemon?limit=\(limit)&offset=\(offset)"

--- a/PokeDex/PokeDex/Model/URLManager.swift
+++ b/PokeDex/PokeDex/Model/URLManager.swift
@@ -1,0 +1,22 @@
+//
+//  URLManager.swift
+//  PokeDex
+//
+//  Created by 장상경 on 12/27/24.
+//
+
+import Foundation
+
+enum URLManager {
+    case pokemonData(limit: Int, offset: Int)
+    case pokemonImage(id: Int)
+    
+    func sendURL() -> String {
+        switch self {
+        case .pokemonData(limit: let limit, offset: let offset):
+            return "https://pokeapi.co/api/v2/pokemon?limit=\(limit)&offset=\(offset)"
+        case .pokemonImage(id: let id):
+            return "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/\(id).png"
+        }
+    }
+}

--- a/PokeDex/PokeDex/View/MainViewController.swift
+++ b/PokeDex/PokeDex/View/MainViewController.swift
@@ -6,14 +6,31 @@
 //
 
 import UIKit
+import SnapKit
 
 class MainViewController: UIViewController {
+    
+    private lazy var pokemonView = PokeDexView(view: PokemonCollectionView())
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        
+        setupUI()
     }
-
-
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.navigationController?.navigationBar.isHidden = true
+    }
+    
+    private func setupUI() {
+        self.view.backgroundColor = .personal
+        self.view.addSubview(self.pokemonView)
+        
+        self.pokemonView.snp.makeConstraints {
+            $0.edges.equalTo(self.view.safeAreaLayoutGuide)
+        }
+    }
 }
 

--- a/PokeDex/PokeDex/View/PokeDexView.swift
+++ b/PokeDex/PokeDex/View/PokeDexView.swift
@@ -1,0 +1,54 @@
+//
+//  PokeDexView.swift
+//  PokeDex
+//
+//  Created by 장상경 on 12/27/24.
+//
+
+import UIKit
+import SnapKit
+
+final class PokeDexView: UIView {
+    
+    private let logo = UIImageView()
+    
+    private let view: UIView?
+    
+    init(view: UIView?) {
+        self.view = view
+        super.init(frame: .zero)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI() {
+        setupLogo()
+        setupLayout()
+    }
+    
+    private func setupLayout() {
+        [self.logo, self.view!].forEach { self.addSubview($0) }
+        
+        self.logo.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.width.height.equalTo(100)
+        }
+        
+        self.view?.snp.makeConstraints {
+            $0.top.equalTo(self.logo.snp.bottom).offset(10)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+    private func setupLogo() {
+        self.logo.image = UIImage(named: "pokedexLogo")
+        self.logo.backgroundColor = .clear
+        self.logo.contentMode = .scaleAspectFit
+    }
+}

--- a/PokeDex/PokeDex/View/PokemonCell.swift
+++ b/PokeDex/PokeDex/View/PokemonCell.swift
@@ -48,7 +48,7 @@ final class PokemonCell: UICollectionViewCell {
         }
     }
     
-    func addImage(_ image: UIImage) {
+    func addImage(_ image: UIImage?) {
         self.imageView.image = image
     }
 }

--- a/PokeDex/PokeDex/View/PokemonCell.swift
+++ b/PokeDex/PokeDex/View/PokemonCell.swift
@@ -1,0 +1,48 @@
+//
+//  PokemonCell.swift
+//  PokeDex
+//
+//  Created by 장상경 on 12/27/24.
+//
+
+import UIKit
+import SnapKit
+
+final class PokemonCell: UICollectionViewCell {
+    static let id: String = "PokemonCell"
+    
+    private let imageView = UIImageView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        setupUI()
+    }
+    
+    private func setupUI() {
+        self.backgroundColor = .white
+        self.layer.cornerRadius = 10
+        
+        self.addSubview(self.imageView)
+        setupImageView()
+    }
+    
+    private func setupImageView() {
+        self.imageView.backgroundColor = .clear
+        self.imageView.contentMode = .scaleAspectFit
+        
+        self.imageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    func addImage(_ image: UIImage) {
+        self.imageView.image = image
+    }
+}

--- a/PokeDex/PokeDex/View/PokemonCell.swift
+++ b/PokeDex/PokeDex/View/PokemonCell.swift
@@ -25,6 +25,12 @@ final class PokemonCell: UICollectionViewCell {
         setupUI()
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        self.imageView.image = nil
+    }
+    
     private func setupUI() {
         self.backgroundColor = .white
         self.layer.cornerRadius = 10

--- a/PokeDex/PokeDex/View/PokemonCollectionView.swift
+++ b/PokeDex/PokeDex/View/PokemonCollectionView.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 final class PokemonCollectionView: UIView {
     
-    private let viewModel = MainViewModel()
+    private let viewModel = MainViewModel(pokemonManager: PokemonManager())
     
     private var pokemonImageList: [UIImage] = []
     
@@ -64,7 +64,7 @@ final class PokemonCollectionView: UIView {
     private func bind() {
         self.viewModel.pokemonImages
             .subscribe(onNext: { [weak self] images in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                DispatchQueue.main.async {
                     self?.pokemonImageList.append(contentsOf: images)
                     self?.collectionView.reloadData()
                 }

--- a/PokeDex/PokeDex/View/PokemonCollectionView.swift
+++ b/PokeDex/PokeDex/View/PokemonCollectionView.swift
@@ -1,0 +1,79 @@
+//
+//  PokemonCollectionView.swift
+//  PokeDex
+//
+//  Created by 장상경 on 12/27/24.
+//
+
+import UIKit
+import SnapKit
+
+final class PokemonCollectionView: UIView {
+    
+    private lazy var collectionView: UICollectionView = {
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
+        cv.delegate = self
+        cv.dataSource = self
+        cv.backgroundColor = .clear
+        cv.showsVerticalScrollIndicator = false
+        cv.showsHorizontalScrollIndicator = false
+        cv.register(PokemonCell.self, forCellWithReuseIdentifier: PokemonCell.id)
+        
+        return cv
+    }()
+    
+    private lazy var collectionViewLayout: UICollectionViewFlowLayout = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 10
+        layout.minimumInteritemSpacing = 10
+        let width = (UIScreen.main.bounds.width / 3) - 15
+        layout.itemSize = .init(width: width, height: width)
+        
+        return layout
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        setupUI()
+    }
+    
+    private func setupUI() {
+        self.backgroundColor = UIColor.personalDark
+        self.addSubview(self.collectionView)
+        
+        self.collectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(10)
+        }
+    }
+    
+}
+
+extension PokemonCollectionView: UICollectionViewDelegate {
+    
+}
+
+extension PokemonCollectionView: UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 20
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PokemonCell.id, for: indexPath) as? PokemonCell else {
+            return UICollectionViewCell()
+        }
+        
+        cell.addImage(UIImage(systemName: "person")!)
+        
+        return cell
+    }
+    
+}

--- a/PokeDex/PokeDex/View/PokemonCollectionView.swift
+++ b/PokeDex/PokeDex/View/PokemonCollectionView.swift
@@ -7,8 +7,13 @@
 
 import UIKit
 import SnapKit
+import RxSwift
 
 final class PokemonCollectionView: UIView {
+    
+    private let viewModel = MainViewModel()
+    
+    private var pokemonImageList: [UIImage] = []
     
     private lazy var collectionView: UICollectionView = {
         let cv = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
@@ -37,12 +42,14 @@ final class PokemonCollectionView: UIView {
         super.init(frame: frame)
         
         setupUI()
+        bind()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         
         setupUI()
+        bind()
     }
     
     private func setupUI() {
@@ -54,6 +61,20 @@ final class PokemonCollectionView: UIView {
         }
     }
     
+    private func bind() {
+        self.viewModel.pokemonImages
+            .subscribe(onNext: { [weak self] images in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    self?.pokemonImageList.append(contentsOf: images)
+                    self?.collectionView.reloadData()
+                }
+                
+            }, onError: { error in
+                print(error)
+                
+            }).disposed(by: self.viewModel.disposeBag)
+    }
+    
 }
 
 extension PokemonCollectionView: UICollectionViewDelegate {
@@ -63,7 +84,7 @@ extension PokemonCollectionView: UICollectionViewDelegate {
 extension PokemonCollectionView: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 20
+        return self.pokemonImageList.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -71,7 +92,7 @@ extension PokemonCollectionView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         
-        cell.addImage(UIImage(systemName: "person")!)
+        cell.addImage(self.pokemonImageList[indexPath.item])
         
         return cell
     }

--- a/PokeDex/PokeDex/ViewModel/MainViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/MainViewModel.swift
@@ -14,29 +14,82 @@ final class MainViewModel {
     
     let disposeBag = DisposeBag()
     
-    let pokeDexData = BehaviorSubject(value: [PokemonData]())
-    
+    private let pokeDexData = BehaviorSubject(value: [PokemonDetailDataModel]())
+    let pokemonImages = BehaviorSubject(value: [UIImage]())
+
     init() {
-        fetchPokeDex(self.pokeDexData)
+        fetchPokemonData(self.pokeDexData)
+        
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+            self.fetchPokemonImage(self.pokemonImages)
+        }
     }
     
     private func fetchData<T: Decodable>(url: URL, decodingType: T.Type) -> Single<T> {
         return NetworkManager.shared.fetch(url: url)
     }
     
-    private func fetchPokeDex(_ subject: BehaviorSubject<[PokemonData]>) {
+    private func fetchPokemonData(_ subject: BehaviorSubject<[PokemonDetailDataModel]>) {
         guard let url = URL(string: "https://pokeapi.co/api/v2/pokemon?limit=\(limit)&offset=\(offset)") else {
             print(NetworkError.invalidURL.errorDescription)
             return
         }
         
         fetchData(url: url, decodingType: PokemonDataModel.self)
-            .subscribe(onSuccess: { data in
-                subject.onNext(data.results)
+            .subscribe(onSuccess: { [weak self] data in
+                self?.fetchPokemonDetaileData(data.results, subject)
                 
             }, onFailure: { error in
                 subject.onError(error)
                 print(NetworkError.dataFetchFail.errorDescription)
+                
+            }).disposed(by: self.disposeBag)
+    }
+    
+    private func fetchPokemonDetaileData(_ datas: [PokemonData], _ subject: BehaviorSubject<[PokemonDetailDataModel]>) {
+        
+        Observable.from(datas)
+            .flatMap { data -> Single<PokemonDetailDataModel> in
+                guard let url = URL(string: data.url) else {
+                    return Single.error(NetworkError.invalidURL)
+                }
+                return self.fetchData(url: url, decodingType: PokemonDetailDataModel.self)
+            }
+            .toArray()
+            .subscribe(onSuccess: { dataList in
+                subject.onNext(dataList)
+                
+            }, onFailure: { error in
+                subject.onError(error)
+                
+            }).disposed(by: self.disposeBag)
+    }
+    
+    private func fetchPokemonImage(_ subject: BehaviorSubject<[UIImage]>) {
+        guard let list = try? self.pokeDexData.value().sorted(by: { $0.id < $1.id }) else { return }
+        
+        Observable.from(list)
+            .subscribe(onNext: { data in
+                
+                guard let url = URL(string: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/\(data.id).png") else {
+                    subject.onError(NetworkError.invalidURL)
+                    return
+                }
+                
+                guard let imageData = try? Data(contentsOf: url) else {
+                    subject.onError(NetworkError.invalidURL)
+                    return
+                }
+                
+                guard let image = UIImage(data: imageData) else {
+                    subject.onError(NetworkError.invalidURL)
+                    return
+                }
+                
+                subject.onNext([image])
+                
+            }, onError: { error in
+                subject.onError(error)
                 
             }).disposed(by: self.disposeBag)
     }

--- a/PokeDex/PokeDex/ViewModel/MainViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/MainViewModel.swift
@@ -9,8 +9,6 @@ import UIKit
 import RxSwift
 
 final class MainViewModel {
-    private let limit: Int = 20
-    private let offset: Int = 0
     private let pokemonManager: PokemonServiceProtocol
     
     let disposeBag = DisposeBag()
@@ -24,7 +22,7 @@ final class MainViewModel {
     }
     
     private func fetchPokemonData() {
-        self.pokemonManager.fetchPokemonList(limit: self.limit, offset: self.offset)
+        self.pokemonManager.fetchPokemonList(limit: 20, offset: 0)
             .flatMap { self.pokemonManager.fetchPokemonDetails($0.results) }
             .subscribe(onSuccess: { [weak self] details in
                 guard let self else { return }
@@ -43,18 +41,8 @@ final class MainViewModel {
         Observable.from(list)
             .subscribe(onNext: { data in
                 
-                guard let url = URL(string: URLManager.pokemonImage(id: data.id).sendURL()) else {
-                    subject.onError(NetworkError.invalidURL)
-                    return
-                }
-                
-                guard let imageData = try? Data(contentsOf: url) else {
-                    subject.onError(NetworkError.invalidURL)
-                    return
-                }
-                
-                guard let image = UIImage(data: imageData) else {
-                    subject.onError(NetworkError.invalidURL)
+                guard let image = NetworkManager.shared.fetchImage(id: data.id) else {
+                    subject.onError(NetworkError.dataFetchFail)
                     return
                 }
                 

--- a/PokeDex/PokeDex/ViewModel/MainViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/MainViewModel.swift
@@ -43,7 +43,7 @@ final class MainViewModel {
         Observable.from(list)
             .subscribe(onNext: { data in
                 
-                guard let url = URL(string: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/\(data.id).png") else {
+                guard let url = URL(string: URLManager.pokemonImage(id: data.id).sendURL()) else {
                     subject.onError(NetworkError.invalidURL)
                     return
                 }

--- a/PokeDex/PokeDex/ViewModel/PokemonServiceProtocol.swift
+++ b/PokeDex/PokeDex/ViewModel/PokemonServiceProtocol.swift
@@ -15,7 +15,7 @@ protocol PokemonServiceProtocol {
 
 final class PokemonManager: PokemonServiceProtocol {
     func fetchPokemonList(limit: Int, offset: Int) -> Single<PokemonDataModel> {
-        guard let url = URL(string: URLManager.pokemonData(limit: limit, offset: offset).sendURL()) else {
+        guard let url = URL(string: URLManager.pokemonData(limit: limit, offset: offset).sendURL) else {
             print(NetworkError.invalidURL.errorDescription)
             return Single.error(NetworkError.invalidURL)
         }

--- a/PokeDex/PokeDex/ViewModel/PokemonServiceProtocol.swift
+++ b/PokeDex/PokeDex/ViewModel/PokemonServiceProtocol.swift
@@ -15,7 +15,7 @@ protocol PokemonServiceProtocol {
 
 final class PokemonManager: PokemonServiceProtocol {
     func fetchPokemonList(limit: Int, offset: Int) -> Single<PokemonDataModel> {
-        guard let url = URL(string: "https://pokeapi.co/api/v2/pokemon?limit=\(limit)&offset=\(offset)") else {
+        guard let url = URL(string: URLManager.pokemonData(limit: limit, offset: offset).sendURL()) else {
             print(NetworkError.invalidURL.errorDescription)
             return Single.error(NetworkError.invalidURL)
         }
@@ -23,7 +23,7 @@ final class PokemonManager: PokemonServiceProtocol {
         return NetworkManager.shared.fetch(url: url)
     }
     
-    func fetchPokemonDetails(_ datas: [PokemonData]) -> RxSwift.Single<[PokemonDetailDataModel]> {
+    func fetchPokemonDetails(_ datas: [PokemonData]) -> Single<[PokemonDetailDataModel]> {
         return Observable.from(datas)
             .flatMap { data -> Single<PokemonDetailDataModel> in
                 guard let url = URL(string: data.url) else {

--- a/PokeDex/PokeDex/ViewModel/PokemonServiceProtocol.swift
+++ b/PokeDex/PokeDex/ViewModel/PokemonServiceProtocol.swift
@@ -1,0 +1,36 @@
+//
+//  FetchModel.swift
+//  PokeDex
+//
+//  Created by 장상경 on 12/27/24.
+//
+
+import UIKit
+import RxSwift
+
+protocol PokemonServiceProtocol {
+    func fetchPokemonList(limit: Int, offset: Int) -> Single<PokemonDataModel>
+    func fetchPokemonDetails(_ datas: [PokemonData]) -> Single<[PokemonDetailDataModel]>
+}
+
+final class PokemonManager: PokemonServiceProtocol {
+    func fetchPokemonList(limit: Int, offset: Int) -> Single<PokemonDataModel> {
+        guard let url = URL(string: "https://pokeapi.co/api/v2/pokemon?limit=\(limit)&offset=\(offset)") else {
+            print(NetworkError.invalidURL.errorDescription)
+            return Single.error(NetworkError.invalidURL)
+        }
+        
+        return NetworkManager.shared.fetch(url: url)
+    }
+    
+    func fetchPokemonDetails(_ datas: [PokemonData]) -> RxSwift.Single<[PokemonDetailDataModel]> {
+        return Observable.from(datas)
+            .flatMap { data -> Single<PokemonDetailDataModel> in
+                guard let url = URL(string: data.url) else {
+                    return Single.error(NetworkError.invalidURL)
+                }
+                return NetworkManager.shared.fetch(url: url)
+            }
+            .toArray()
+    }
+}


### PR DESCRIPTION
## ✨New Content✨
- 포켓몬 컬렉션 셀 구현
- 포켓몬 컬렉션뷰 구현
- 메인 뷰 컨트롤러 구현
- 데이터 바인딩 구현
- URL 관리 모듈 구현
- 네트워크 매니터 메소드 추가

## ♻️Change Point♻️
- 컬렉션뷰를 `compositionalLayout`으로 구현하려고 했으나, 과한 옵션 같아서 `FlowLayout`으로 구현
- URL을 직접 사용하지 않고, 관리하는 `enum`을 만들어 사용

## 🚨Truble🚨
1. API 통신을 통해 이미지를 불러와야 하는데 코드가 복잡하게 꼬여있음 -> 리팩토링으로 구조를 단순화하여 해결
2. 이미지를 불러오는 메소드가 데이터모델을 불러오는 메소드보다 일찍 종료되는 탓에 셀에 이미지가 표시되지 않음 -> 데이터 모델을 불러오는 메소드 내부에 이미지를 불러오는 메소드를 호출하여 해결
3. 불러온 이미지가 순서대로 정렬되지 않고 랜덤하게 배열됨 -> `sorted` 메소드를 사용하여 각 포켓몬 id에 따라 내림차순으로 정렬되도록 구현하여 해결

## 구현 결과

![Simulator Screenshot - iPhone 16 Pro - 2024-12-27 at 19 23 09](https://github.com/user-attachments/assets/59e25cfd-0ff1-439d-963e-49ff90a24844)

close #7 
