### PR TITLE
[feat] 포켓몬 디테일 뷰 구현

### DIFF
--- a/PokeDex/PokeDex.xcodeproj/project.pbxproj
+++ b/PokeDex/PokeDex.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		AA75C7262D1E3D26009B2A9D /* PokeDexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */; };
 		AA75C7282D1E7244009B2A9D /* PokemonServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7272D1E7244009B2A9D /* PokemonServiceProtocol.swift */; };
 		AA75C72A2D1E9E39009B2A9D /* URLManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7292D1E9E39009B2A9D /* URLManager.swift */; };
+		AA75C72C2D1F9654009B2A9D /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C72B2D1F9654009B2A9D /* DetailViewModel.swift */; };
+		AA75C72E2D1F9663009B2A9D /* DetaileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C72D2D1F9663009B2A9D /* DetaileViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +46,8 @@
 		AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokeDexView.swift; sourceTree = "<group>"; };
 		AA75C7272D1E7244009B2A9D /* PokemonServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonServiceProtocol.swift; sourceTree = "<group>"; };
 		AA75C7292D1E9E39009B2A9D /* URLManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLManager.swift; sourceTree = "<group>"; };
+		AA75C72B2D1F9654009B2A9D /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
+		AA75C72D2D1F9663009B2A9D /* DetaileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetaileViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +101,7 @@
 				AA75C7212D1E3252009B2A9D /* PokemonCell.swift */,
 				AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */,
 				AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */,
+				AA75C72D2D1F9663009B2A9D /* DetaileViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -106,6 +111,7 @@
 			children = (
 				AA75C71F2D1D6D95009B2A9D /* MainViewModel.swift */,
 				AA75C7272D1E7244009B2A9D /* PokemonServiceProtocol.swift */,
+				AA75C72B2D1F9654009B2A9D /* DetailViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -208,8 +214,10 @@
 				AA75C7192D1D635B009B2A9D /* PokemonDetailDataModel.swift in Sources */,
 				AA75C7032D1D1A9C009B2A9D /* AppDelegate.swift in Sources */,
 				AA75C7262D1E3D26009B2A9D /* PokeDexView.swift in Sources */,
+				AA75C72E2D1F9663009B2A9D /* DetaileViewController.swift in Sources */,
 				AA75C7042D1D1A9C009B2A9D /* MainViewController.swift in Sources */,
 				AA75C7052D1D1A9C009B2A9D /* SceneDelegate.swift in Sources */,
+				AA75C72C2D1F9654009B2A9D /* DetailViewModel.swift in Sources */,
 				AA75C7152D1D4FA9009B2A9D /* NetworkError.swift in Sources */,
 				AA75C7202D1D6D95009B2A9D /* MainViewModel.swift in Sources */,
 				AA75C7242D1E3496009B2A9D /* PokemonCollectionView.swift in Sources */,

--- a/PokeDex/PokeDex.xcodeproj/project.pbxproj
+++ b/PokeDex/PokeDex.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		AA75C72A2D1E9E39009B2A9D /* URLManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C7292D1E9E39009B2A9D /* URLManager.swift */; };
 		AA75C72C2D1F9654009B2A9D /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C72B2D1F9654009B2A9D /* DetailViewModel.swift */; };
 		AA75C72E2D1F9663009B2A9D /* DetaileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C72D2D1F9663009B2A9D /* DetaileViewController.swift */; };
+		AA75C7302D1F9BB6009B2A9D /* PokemonDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA75C72F2D1F9BB6009B2A9D /* PokemonDetailView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -48,6 +49,7 @@
 		AA75C7292D1E9E39009B2A9D /* URLManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLManager.swift; sourceTree = "<group>"; };
 		AA75C72B2D1F9654009B2A9D /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
 		AA75C72D2D1F9663009B2A9D /* DetaileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetaileViewController.swift; sourceTree = "<group>"; };
+		AA75C72F2D1F9BB6009B2A9D /* PokemonDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonDetailView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +104,7 @@
 				AA75C7232D1E3496009B2A9D /* PokemonCollectionView.swift */,
 				AA75C7252D1E3D26009B2A9D /* PokeDexView.swift */,
 				AA75C72D2D1F9663009B2A9D /* DetaileViewController.swift */,
+				AA75C72F2D1F9BB6009B2A9D /* PokemonDetailView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -216,6 +219,7 @@
 				AA75C7262D1E3D26009B2A9D /* PokeDexView.swift in Sources */,
 				AA75C72E2D1F9663009B2A9D /* DetaileViewController.swift in Sources */,
 				AA75C7042D1D1A9C009B2A9D /* MainViewController.swift in Sources */,
+				AA75C7302D1F9BB6009B2A9D /* PokemonDetailView.swift in Sources */,
 				AA75C7052D1D1A9C009B2A9D /* SceneDelegate.swift in Sources */,
 				AA75C72C2D1F9654009B2A9D /* DetailViewModel.swift in Sources */,
 				AA75C7152D1D4FA9009B2A9D /* NetworkError.swift in Sources */,

--- a/PokeDex/PokeDex/Model/PokemonDetailDataModel.swift
+++ b/PokeDex/PokeDex/Model/PokemonDetailDataModel.swift
@@ -10,8 +10,8 @@ import Foundation
 struct PokemonDetailDataModel: Decodable {
     let id: Int
     let name: String
-    let height: Int
-    let weight: Int
+    let height: Double
+    let weight: Double
     let types: [PokemonTypes]
 }
 

--- a/PokeDex/PokeDex/Model/URLManager.swift
+++ b/PokeDex/PokeDex/Model/URLManager.swift
@@ -9,12 +9,15 @@ import Foundation
 
 enum URLManager {
     case pokemonData(limit: Int, offset: Int)
+    case pokemonDetailData(id: Int)
     case pokemonImage(id: Int)
     
     var sendURL: String {
         switch self {
         case .pokemonData(limit: let limit, offset: let offset):
             return "https://pokeapi.co/api/v2/pokemon?limit=\(limit)&offset=\(offset)"
+        case .pokemonDetailData(id: let id):
+            return "https://pokeapi.co/api/v2/pokemon/\(id)/"
         case .pokemonImage(id: let id):
             return "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/\(id).png"
         }

--- a/PokeDex/PokeDex/View/DetaileViewController.swift
+++ b/PokeDex/PokeDex/View/DetaileViewController.swift
@@ -5,4 +5,42 @@
 //  Created by 장상경 on 12/28/24.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+
+final class DetaileViewController: UIViewController {
+    
+    private let detailView: PokemonDetailView
+    
+    init(detailView: PokemonDetailView) {
+        self.detailView = detailView
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configure()
+    }
+    
+    private func configure() {
+        self.navigationController?.navigationBar.isHidden = false
+        self.navigationController?.navigationBar.tintColor = .pointBlue
+        self.view.backgroundColor = .personal
+        self.view.addSubview(self.detailView)
+        
+        setupDetailViewLayout()
+    }
+    
+    private func setupDetailViewLayout() {
+        self.detailView.snp.makeConstraints {
+            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(10)
+            $0.height.equalTo(200)
+        }
+    }
+}

--- a/PokeDex/PokeDex/View/DetaileViewController.swift
+++ b/PokeDex/PokeDex/View/DetaileViewController.swift
@@ -39,8 +39,8 @@ final class DetaileViewController: UIViewController {
     private func setupDetailViewLayout() {
         self.detailView.snp.makeConstraints {
             $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(10)
-            $0.leading.trailing.equalToSuperview().inset(10)
-            $0.height.equalTo(200)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(self.view.bounds.height * 0.5)
         }
     }
 }

--- a/PokeDex/PokeDex/View/DetaileViewController.swift
+++ b/PokeDex/PokeDex/View/DetaileViewController.swift
@@ -1,0 +1,8 @@
+//
+//  DetaileViewController.swift
+//  PokeDex
+//
+//  Created by 장상경 on 12/28/24.
+//
+
+import Foundation

--- a/PokeDex/PokeDex/View/PokemonCollectionView.swift
+++ b/PokeDex/PokeDex/View/PokemonCollectionView.swift
@@ -82,7 +82,7 @@ extension PokemonCollectionView: UICollectionViewDelegate {
         
         let detailView = PokemonDetailView(
             image: self.pokemonImageList[indexPath.item],
-            model: DetailViewModel(pokemonManager: PokemonManager(), id: indexPath.item)
+            model: DetailViewModel(pokemonManager: PokemonManager(), id: indexPath.item + 1)
         )
         
         guard let view = self.window?.rootViewController as? UINavigationController else { return }

--- a/PokeDex/PokeDex/View/PokemonCollectionView.swift
+++ b/PokeDex/PokeDex/View/PokemonCollectionView.swift
@@ -78,7 +78,16 @@ final class PokemonCollectionView: UIView {
 }
 
 extension PokemonCollectionView: UICollectionViewDelegate {
-    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        let detailView = PokemonDetailView(
+            image: self.pokemonImageList[indexPath.item],
+            model: DetailViewModel(pokemonManager: PokemonManager(), id: indexPath.item)
+        )
+        
+        guard let view = self.window?.rootViewController as? UINavigationController else { return }
+        view.pushViewController(DetaileViewController(detailView: detailView), animated: true)
+    }
 }
 
 extension PokemonCollectionView: UICollectionViewDataSource {

--- a/PokeDex/PokeDex/View/PokemonDetailView.swift
+++ b/PokeDex/PokeDex/View/PokemonDetailView.swift
@@ -95,7 +95,7 @@ final class PokemonDetailView: UIView {
     private func bind() {
         self.viewModel.pokemonDetailData
             .subscribe(onNext: { [weak self] data in
-                guard let self , let data = data.first else { return }
+                guard let self, let data = data.first else { return }
                 guard let type = data.types.first?.type.name else { return }
                 
                 DispatchQueue.main.async {

--- a/PokeDex/PokeDex/View/PokemonDetailView.swift
+++ b/PokeDex/PokeDex/View/PokemonDetailView.swift
@@ -7,31 +7,34 @@
 
 import UIKit
 import SnapKit
+import RxSwift
 
 final class PokemonDetailView: UIView {
+    
+    private let disposeBag = DisposeBag()
+    
+    private let viewModel: DetailViewModel
     
     private let imageView = UIImageView()
     private let nameLabel = UILabel()
     private let detailLabel = UILabel()
     
-    init(image: UIImage, data: PokemonDetailDataModel) {
+    init(image: UIImage, model: DetailViewModel) {
+        self.viewModel = model
         super.init(frame: .zero)
-        self.imageView.image = image
-        self.nameLabel.text = "No.\(data.id) \(data.name)"
-        self.detailLabel.text = "타입: \(data.types[0].type.name)\n키: \(data.height) m\n몸무게: \(data.weight) kg"
         
         configure()
+        bind()
+        self.imageView.image = image
     }
     
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        
-        configure()
+        fatalError("init(coder:) has not been implemented")
     }
     
     private func configure() {
         self.backgroundColor = .personalDark
-        self.layer.cornerRadius = 10
+        self.layer.cornerRadius = 20
         self.clipsToBounds = true
         [self.imageView,
          self.nameLabel,
@@ -46,10 +49,11 @@ final class PokemonDetailView: UIView {
     private func setupImage() {
         self.imageView.contentMode = .scaleAspectFit
         self.imageView.backgroundColor = .clear
+        self.imageView.image = UIImage(systemName: "person") // 테스트
     }
     
     private func setupNameLabel() {
-        self.nameLabel.font = UIFont.boldSystemFont(ofSize: 20)
+        self.nameLabel.font = UIFont.boldSystemFont(ofSize: 30)
         self.nameLabel.textAlignment = .center
         self.nameLabel.textColor = .white
         self.nameLabel.numberOfLines = 1
@@ -57,7 +61,7 @@ final class PokemonDetailView: UIView {
     }
     
     private func setupDetailLabel() {
-        self.detailLabel.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        self.detailLabel.font = UIFont.systemFont(ofSize: 20, weight: .regular)
         self.detailLabel.textAlignment = .center
         self.detailLabel.textColor = .white
         self.detailLabel.numberOfLines = 3
@@ -68,7 +72,7 @@ final class PokemonDetailView: UIView {
         self.imageView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(20)
             $0.centerX.equalToSuperview()
-            $0.width.height.equalTo(120)
+            $0.width.height.equalTo(250)
         }
         
         self.nameLabel.snp.makeConstraints {
@@ -80,5 +84,46 @@ final class PokemonDetailView: UIView {
             $0.top.equalTo(self.nameLabel.snp.bottom).offset(10)
             $0.centerX.equalToSuperview()
         }
+    }
+    
+    private func labelConfig(id: Int, name: String, type: String, height: Double, weight: Double) {
+        self.nameLabel.text = "No.\(id) \(name)"
+        self.detailLabel.text = "타입: \(type)\n키: \(height) m\n몸무게: \(weight) kg"
+        self.detailLabel.lineSpacing(10)
+    }
+    
+    private func bind() {
+        self.viewModel.pokemonDetailData
+            .subscribe(onNext: { [weak self] data in
+                guard let self , let data = data.first else { return }
+                guard let type = data.types.first?.type.name else { return }
+                
+                DispatchQueue.main.async {
+                    self.labelConfig(id: data.id,
+                                     name: data.name,
+                                     type: type,
+                                     height: data.height,
+                                     weight: data.weight)
+                }
+                
+            }, onError: { error in
+            
+                
+                
+            }).disposed(by: self.disposeBag)
+    }
+}
+
+extension UILabel {
+    func lineSpacing(_ spacing: CGFloat) {
+        guard let text = self.text else { return }
+        
+        let attributeString = NSMutableAttributedString(string: text)
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = spacing
+        style.alignment = .center
+        attributeString.addAttribute(.paragraphStyle, value: style, range: NSRange(location: 0, length: attributeString.length))
+        
+        self.attributedText = attributeString
     }
 }

--- a/PokeDex/PokeDex/View/PokemonDetailView.swift
+++ b/PokeDex/PokeDex/View/PokemonDetailView.swift
@@ -96,14 +96,25 @@ final class PokemonDetailView: UIView {
         self.viewModel.pokemonDetailData
             .subscribe(onNext: { [weak self] data in
                 guard let self, let data = data.first else { return }
-                guard let type = data.types.first?.type.name else { return }
+                var type: String = ""
+                
+                if data.types.count > 1 {
+                    var types = [String](repeating: "", count: data.types.count)
+                    for type in data.types {
+                        types[type.slot - 1] = type.type.name
+                    }
+                    type = types.joined(separator: ", ")
+                    
+                } else {
+                    type = data.types.first?.type.name ?? ""
+                }
                 
                 DispatchQueue.main.async {
                     self.labelConfig(id: data.id,
                                      name: data.name,
                                      type: type,
-                                     height: data.height,
-                                     weight: data.weight)
+                                     height: data.height / 10,
+                                     weight: data.weight / 10)
                 }
                 
             }, onError: { error in

--- a/PokeDex/PokeDex/View/PokemonDetailView.swift
+++ b/PokeDex/PokeDex/View/PokemonDetailView.swift
@@ -1,0 +1,84 @@
+//
+//  PokemonDetailView.swift
+//  PokeDex
+//
+//  Created by 장상경 on 12/28/24.
+//
+
+import UIKit
+import SnapKit
+
+final class PokemonDetailView: UIView {
+    
+    private let imageView = UIImageView()
+    private let nameLabel = UILabel()
+    private let detailLabel = UILabel()
+    
+    init(image: UIImage, data: PokemonDetailDataModel) {
+        super.init(frame: .zero)
+        self.imageView.image = image
+        self.nameLabel.text = "No.\(data.id) \(data.name)"
+        self.detailLabel.text = "타입: \(data.types[0].type.name)\n키: \(data.height) m\n몸무게: \(data.weight) kg"
+        
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        configure()
+    }
+    
+    private func configure() {
+        self.backgroundColor = .personalDark
+        self.layer.cornerRadius = 10
+        self.clipsToBounds = true
+        [self.imageView,
+         self.nameLabel,
+         self.detailLabel].forEach { self.addSubview($0) }
+        
+        setupImage()
+        setupNameLabel()
+        setupDetailLabel()
+        setupLayout()
+    }
+    
+    private func setupImage() {
+        self.imageView.contentMode = .scaleAspectFit
+        self.imageView.backgroundColor = .clear
+    }
+    
+    private func setupNameLabel() {
+        self.nameLabel.font = UIFont.boldSystemFont(ofSize: 20)
+        self.nameLabel.textAlignment = .center
+        self.nameLabel.textColor = .white
+        self.nameLabel.numberOfLines = 1
+        self.nameLabel.backgroundColor = .clear
+    }
+    
+    private func setupDetailLabel() {
+        self.detailLabel.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        self.detailLabel.textAlignment = .center
+        self.detailLabel.textColor = .white
+        self.detailLabel.numberOfLines = 3
+        self.detailLabel.backgroundColor = .clear
+    }
+    
+    private func setupLayout() {
+        self.imageView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(20)
+            $0.centerX.equalToSuperview()
+            $0.width.height.equalTo(120)
+        }
+        
+        self.nameLabel.snp.makeConstraints {
+            $0.top.equalTo(self.imageView.snp.bottom).offset(10)
+            $0.centerX.equalToSuperview()
+        }
+        
+        self.detailLabel.snp.makeConstraints {
+            $0.top.equalTo(self.nameLabel.snp.bottom).offset(10)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}

--- a/PokeDex/PokeDex/ViewModel/DetailViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/DetailViewModel.swift
@@ -22,17 +22,11 @@ final class DetailViewModel {
     }
     
     private func fetchPokemonData(id: Int) {
-        self.pokemonManager.fetchPokemonList(limit: id, offset: id)
-            .flatMap { [weak self] in
-                guard let self else {
-                    return Single.error(NetworkError.dataFetchFail)
-                }
-                return self.pokemonManager.fetchPokemonDetails($0.results)
-            }
-            .subscribe(onSuccess: { [weak self] (details: [PokemonDetailDataModel]) in
+        self.pokemonManager.fetchPokemonData(urlType: .pokemonDetailData(id: id), modelType: PokemonDetailDataModel.self)
+            .subscribe(onSuccess: { [weak self] (details: PokemonDetailDataModel) in
                 guard let self else { return }
                 
-                self.pokemonDetailData.onNext(details)
+                self.pokemonDetailData.onNext([details])
                 
             }, onFailure: { error in
                 self.pokemonDetailData.onError(error)

--- a/PokeDex/PokeDex/ViewModel/DetailViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/DetailViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  DetailViewModel.swift
+//  PokeDex
+//
+//  Created by 장상경 on 12/28/24.
+//
+
+import Foundation

--- a/PokeDex/PokeDex/ViewModel/DetailViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/DetailViewModel.swift
@@ -5,4 +5,38 @@
 //  Created by 장상경 on 12/28/24.
 //
 
-import Foundation
+import UIKit
+import RxSwift
+
+final class DetailViewModel {
+    private let pokemonManager: PokemonServiceProtocol
+    
+    private let disposeBag = DisposeBag()
+    
+    let pokemonDetailData = BehaviorSubject(value: [PokemonDetailDataModel]())
+    
+    init(pokemonManager: PokemonServiceProtocol, id: Int) {
+        self.pokemonManager = pokemonManager
+        
+        fetchPokemonData(id: id)
+    }
+    
+    private func fetchPokemonData(id: Int) {
+        self.pokemonManager.fetchPokemonList(limit: id, offset: id)
+            .flatMap { [weak self] in
+                guard let self else {
+                    return Single.error(NetworkError.dataFetchFail)
+                }
+                return self.pokemonManager.fetchPokemonDetails($0.results)
+            }
+            .subscribe(onSuccess: { [weak self] (details: [PokemonDetailDataModel]) in
+                guard let self else { return }
+                
+                self.pokemonDetailData.onNext(details)
+                
+            }, onFailure: { error in
+                self.pokemonDetailData.onError(error)
+                
+            }).disposed(by: self.disposeBag)
+    }
+}

--- a/PokeDex/PokeDex/ViewModel/MainViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/MainViewModel.swift
@@ -23,8 +23,13 @@ final class MainViewModel {
     
     private func fetchPokemonData() {
         self.pokemonManager.fetchPokemonList(limit: 20, offset: 0)
-            .flatMap { self.pokemonManager.fetchPokemonDetails($0.results) }
-            .subscribe(onSuccess: { [weak self] details in
+            .flatMap { [weak self] in
+                guard let self else {
+                    return Single.error(NetworkError.dataFetchFail)
+                }
+                return self.pokemonManager.fetchPokemonDetails($0.results)
+            }
+            .subscribe(onSuccess: { [weak self] (details: [PokemonDetailDataModel]) in
                 guard let self else { return }
                 
                 self.fetchPokemonImage(details: details, self.pokemonImages)

--- a/PokeDex/PokeDex/ViewModel/MainViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/MainViewModel.swift
@@ -22,7 +22,7 @@ final class MainViewModel {
     }
     
     private func fetchPokemonData() {
-        self.pokemonManager.fetchPokemonList(limit: 20, offset: 0)
+        self.pokemonManager.fetchPokemonData(urlType: .pokemonData(limit: 20, offset: 0), modelType: PokemonDataModel.self)
             .flatMap { [weak self] in
                 guard let self else {
                     return Single.error(NetworkError.dataFetchFail)

--- a/PokeDex/PokeDex/ViewModel/PokemonServiceProtocol.swift
+++ b/PokeDex/PokeDex/ViewModel/PokemonServiceProtocol.swift
@@ -9,13 +9,14 @@ import UIKit
 import RxSwift
 
 protocol PokemonServiceProtocol {
-    func fetchPokemonList(limit: Int, offset: Int) -> Single<PokemonDataModel>
+    func fetchPokemonData<T: Decodable>(urlType: URLManager, modelType: T.Type) -> Single<T>
     func fetchPokemonDetails(_ datas: [PokemonData]) -> Single<[PokemonDetailDataModel]>
 }
 
 final class PokemonManager: PokemonServiceProtocol {
-    func fetchPokemonList(limit: Int, offset: Int) -> Single<PokemonDataModel> {
-        guard let url = URL(string: URLManager.pokemonData(limit: limit, offset: offset).sendURL) else {
+    
+    func fetchPokemonData<T: Decodable>(urlType: URLManager, modelType: T.Type) -> Single<T> {
+        guard let url = URL(string: urlType.sendURL) else {
             print(NetworkError.invalidURL.errorDescription)
             return Single.error(NetworkError.invalidURL)
         }


### PR DESCRIPTION
## ✨New Content✨
- 포켓몬 디테일 모델 뷰 구현
- 포켓몬 디테일 뷰 구현
- 포켓몬 디테일 뷰 컨트롤러 구현
- 메인 뷰 셀 선택 액션 구현
- 포켓몬 데이터 URL 추가

## ♻️Change Point♻️
- PokemonService 프로토콜 메소드 수정 -> 재활용성 향상
- PokemonManager 메소드 구현 변경 -> 재활용성 향상
- 메인 뷰 모델 메소드 변경 -> PokemonManager의 메소드가 변경되어 이에 맞춰 변경

## 🚨Truble🚨
셀 선택 액션으로 디테일 뷰로 이동할 때, 데이터 바인딩을 통해 디테일 뷰에 포켓몬에 대한 정보(이름, 키, 몸무게 등)을 표기해야 한다.
그런데, 메소드를 좀 수정하니까 정보가 표시되지 않는 버그가 발생했다.

원인을 찾기 위해 브레이크 포인트를 걸며 어디가 문제인지 하나하나 찾아가다 보니 `NetworkManger`의 `fetch`메소드에서 문제가 발생한 것임을 확인할 수 있었다.

그래서 네트워크 매니저의 어떤 부분이 문제인지 확인하기 위해 다시 브레이크 포인트를 하나씩 걸어가며 확인해본 결과, `response`를 `HTTPURLResponse`로 타입 캐스팅 한 후 `statusCode`를 확인하는 부분에서 return 되는 것을 알 수 있었다.

이 부분에 브레이크 포인트를 걸어 `statusCode`를 확인해 보았는데...

![스크린샷 2024-12-28 14 30 30](https://github.com/user-attachments/assets/47fd1c6e-18c2-43a5-ac33-e393b969343b)

이렇게 `404`로 200~299 범위 밖의 값이 출력된 것을 확인할 수 있었다.
익숙한 숫자에 혹시 URL이 잘못 되었나? 확인해 보았는데...

![스크린샷 2024-12-28 14 32 41](https://github.com/user-attachments/assets/7c0f7199-866e-4ba3-86d2-8d21f7e96caa)

알고보니 링크의 끝에 공백(" ")이 추가되어 있었다. 설마 고작 공백 때문일까... 싶으면서도 혹시 몰라 공백을 제거하고 빌드를 해봤는데, 놀랍게도 데이터 표기가 다시 정상적으로 이루어졌다...

정말 사소한 실수 때문에 30분 정도 시간을 소비한 것 같아서 허탈했다... 앞으로는 URL을 작성할 때 더 주의를 기울여야겠다고 생각했다...

### 구현 영상

![무제](https://github.com/user-attachments/assets/23a55ee2-e479-456a-8ac3-cfaa60e9464f)



close #9 