### PR TITLE
[fix] 버그 해결 및 최적화

### DIFF
--- a/PokeDex/PokeDex.xcodeproj/project.pbxproj
+++ b/PokeDex/PokeDex.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		AA9AA8632D237FA400EA7F09 /* SearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA8622D237FA400EA7F09 /* SearchTableViewCell.swift */; };
 		AA9AA8652D237FAC00EA7F09 /* SearchTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA8642D237FAC00EA7F09 /* SearchTableView.swift */; };
 		AA9AA9072D23D89B00EA7F09 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA9062D23D89B00EA7F09 /* SearchViewModel.swift */; };
+		AA9AA90D2D2633A600EA7F09 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = AA9AA90C2D2633A600EA7F09 /* Kingfisher */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -83,6 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA9AA90D2D2633A600EA7F09 /* Kingfisher in Frameworks */,
 				AA75C7112D1D1CB0009B2A9D /* RxCocoa in Frameworks */,
 				AA75C70E2D1D1BDC009B2A9D /* SnapKit in Frameworks */,
 			);
@@ -245,6 +247,7 @@
 			packageProductDependencies = (
 				AA75C70D2D1D1BDC009B2A9D /* SnapKit */,
 				AA75C7102D1D1CB0009B2A9D /* RxCocoa */,
+				AA9AA90C2D2633A600EA7F09 /* Kingfisher */,
 			);
 			productName = PokeDex;
 			productReference = AA75C6E32D1D1A2C009B2A9D /* PokeDex.app */;
@@ -277,6 +280,7 @@
 			packageReferences = (
 				AA75C70C2D1D1BDC009B2A9D /* XCRemoteSwiftPackageReference "SnapKit" */,
 				AA75C70F2D1D1CB0009B2A9D /* XCRemoteSwiftPackageReference "RxSwift" */,
+				AA9AA90B2D2633A600EA7F09 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = AA75C6E42D1D1A2C009B2A9D /* Products */;
@@ -566,6 +570,14 @@
 				minimumVersion = 6.8.0;
 			};
 		};
+		AA9AA90B2D2633A600EA7F09 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.1.3;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -578,6 +590,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA75C70F2D1D1CB0009B2A9D /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxCocoa;
+		};
+		AA9AA90C2D2633A600EA7F09 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA9AA90B2D2633A600EA7F09 /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/PokeDex/PokeDex.xcodeproj/project.pbxproj
+++ b/PokeDex/PokeDex.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		AA9AA6AD2D22B95F00EA7F09 /* MainTabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA6AC2D22B95F00EA7F09 /* MainTabBarCell.swift */; };
 		AA9AA6AF2D22B98D00EA7F09 /* MainTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA6AE2D22B98D00EA7F09 /* MainTabBarView.swift */; };
 		AA9AA73E2D22C47300EA7F09 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA73D2D22C47300EA7F09 /* ViewController.swift */; };
-		AA9AA7402D22C7EF00EA7F09 /* SelectEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA73F2D22C7EF00EA7F09 /* SelectEffect.swift */; };
+		AA9AA7402D22C7EF00EA7F09 /* TabBarIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA73F2D22C7EF00EA7F09 /* TabBarIndicator.swift */; };
 		AA9AA85C2D23759900EA7F09 /* TabBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA85B2D23759900EA7F09 /* TabBarViewModel.swift */; };
 		AA9AA85F2D237F7900EA7F09 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA85E2D237F7900EA7F09 /* SearchView.swift */; };
 		AA9AA8612D237F8100EA7F09 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9AA8602D237F8100EA7F09 /* SearchViewController.swift */; };
@@ -70,7 +70,7 @@
 		AA9AA6AC2D22B95F00EA7F09 /* MainTabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarCell.swift; sourceTree = "<group>"; };
 		AA9AA6AE2D22B98D00EA7F09 /* MainTabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarView.swift; sourceTree = "<group>"; };
 		AA9AA73D2D22C47300EA7F09 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		AA9AA73F2D22C7EF00EA7F09 /* SelectEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectEffect.swift; sourceTree = "<group>"; };
+		AA9AA73F2D22C7EF00EA7F09 /* TabBarIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarIndicator.swift; sourceTree = "<group>"; };
 		AA9AA85B2D23759900EA7F09 /* TabBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewModel.swift; sourceTree = "<group>"; };
 		AA9AA85E2D237F7900EA7F09 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		AA9AA8602D237F8100EA7F09 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
@@ -212,7 +212,7 @@
 				AA9AA6AA2D22B95300EA7F09 /* MainTabBarController.swift */,
 				AA9AA6AC2D22B95F00EA7F09 /* MainTabBarCell.swift */,
 				AA9AA6AE2D22B98D00EA7F09 /* MainTabBarView.swift */,
-				AA9AA73F2D22C7EF00EA7F09 /* SelectEffect.swift */,
+				AA9AA73F2D22C7EF00EA7F09 /* TabBarIndicator.swift */,
 			);
 			path = TabBar;
 			sourceTree = "<group>";
@@ -333,7 +333,7 @@
 				AA9AA85C2D23759900EA7F09 /* TabBarViewModel.swift in Sources */,
 				AA75C7342D1FC75E009B2A9D /* PokemonTypeTranslator.swift in Sources */,
 				AA9AA6AF2D22B98D00EA7F09 /* MainTabBarView.swift in Sources */,
-				AA9AA7402D22C7EF00EA7F09 /* SelectEffect.swift in Sources */,
+				AA9AA7402D22C7EF00EA7F09 /* TabBarIndicator.swift in Sources */,
 				AA75C7152D1D4FA9009B2A9D /* NetworkError.swift in Sources */,
 				AA75C7202D1D6D95009B2A9D /* MainViewModel.swift in Sources */,
 				AA75C7242D1E3496009B2A9D /* PokemonCollectionView.swift in Sources */,

--- a/PokeDex/PokeDex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PokeDex/PokeDex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "cd3d641b9769728c2b0ab2a3ddd1ac348a24916b0d2c4757638218ed952a9c9b",
+  "originHash" : "1e243e54d95e843322e8a2436a0455b85dc2f638aa2e8fb90c2a7ba7d9ee96c6",
   "pins" : [
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher",
+      "state" : {
+        "revision" : "e6749919f9761d573d37a7d7e78b1b854c191d7f",
+        "version" : "8.1.3"
+      }
+    },
     {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",

--- a/PokeDex/PokeDex/Model/DataModel/PokemonDataModel.swift
+++ b/PokeDex/PokeDex/Model/DataModel/PokemonDataModel.swift
@@ -9,12 +9,10 @@ import Foundation
 
 // 포켓몬 리스트를 가져오는 데이터 타입
 struct PokemonDataModel: Decodable {
-    let next: String
     let results: [PokemonData]
 }
 
 // 각 포켓몬의 데이터를 담은 데이터 타입
 struct PokemonData: Decodable {
     let name: String
-    let url: String
 }

--- a/PokeDex/PokeDex/Model/Network/NetworkManager.swift
+++ b/PokeDex/PokeDex/Model/Network/NetworkManager.swift
@@ -51,27 +51,27 @@ final class NetworkManager {
         }
     }
     
-    /// API 통신을 통해 포켓몬 이미지를 가져오는 메소드
-    /// - Parameter id:포켓몬의 도감 번호
-    /// - Returns: 포켓몬 이미지
-    func fetchImage(id: Int) -> UIImage? {
-        var resultImage: UIImage?
-        guard let url = URL(string: APIEndpoint.pokemonImageURL(id: id).urlString) else { return nil }
-        
-        DispatchQueue.global().sync {
-            guard let imageData = try? Data(contentsOf: url) else {
-                resultImage = nil
-                return
-            }
-            
-            guard let image = UIImage(data: imageData) else {
-                resultImage = nil
-                return
-            }
-            
-            resultImage = image
-        }
-        
-        return resultImage
-    }
+//    /// API 통신을 통해 포켓몬 이미지를 가져오는 메소드
+//    /// - Parameter id:포켓몬의 도감 번호
+//    /// - Returns: 포켓몬 이미지
+//    func fetchImage(id: Int) -> UIImage? {
+//        var resultImage: UIImage?
+//        guard let url = URL(string: APIEndpoint.pokemonImageURL(id: id).urlString) else { return nil }
+//        
+//        DispatchQueue.global().sync {
+//            guard let imageData = try? Data(contentsOf: url) else {
+//                resultImage = nil
+//                return
+//            }
+//            
+//            guard let image = UIImage(data: imageData) else {
+//                resultImage = nil
+//                return
+//            }
+//            
+//            resultImage = image
+//        }
+//        
+//        return resultImage
+//    }
 }

--- a/PokeDex/PokeDex/Model/Network/NetworkManager.swift
+++ b/PokeDex/PokeDex/Model/Network/NetworkManager.swift
@@ -50,28 +50,4 @@ final class NetworkManager {
             return Disposables.create()
         }
     }
-    
-//    /// API 통신을 통해 포켓몬 이미지를 가져오는 메소드
-//    /// - Parameter id:포켓몬의 도감 번호
-//    /// - Returns: 포켓몬 이미지
-//    func fetchImage(id: Int) -> UIImage? {
-//        var resultImage: UIImage?
-//        guard let url = URL(string: APIEndpoint.pokemonImageURL(id: id).urlString) else { return nil }
-//        
-//        DispatchQueue.global().sync {
-//            guard let imageData = try? Data(contentsOf: url) else {
-//                resultImage = nil
-//                return
-//            }
-//            
-//            guard let image = UIImage(data: imageData) else {
-//                resultImage = nil
-//                return
-//            }
-//            
-//            resultImage = image
-//        }
-//        
-//        return resultImage
-//    }
 }

--- a/PokeDex/PokeDex/View/DetailView/PokemonDetailView.swift
+++ b/PokeDex/PokeDex/View/DetailView/PokemonDetailView.swift
@@ -8,6 +8,7 @@
 import UIKit
 import SnapKit
 import RxSwift
+import Kingfisher
 
 // 포켓몬 디테일 뷰
 final class PokemonDetailView: UIView {
@@ -21,13 +22,13 @@ final class PokemonDetailView: UIView {
     private let infoLabel = UILabel()
     
     // MARK: - PokemonDetailView Initializer
-    init(image: UIImage, model: DetailViewModel) {
+    init(id: Int, model: DetailViewModel) {
         self.viewModel = model
         super.init(frame: .zero)
         
         setupUI()
+        addImage(id: id)
         bind()
-        self.imageView.image = image
     }
     
     required init?(coder: NSCoder) {
@@ -160,6 +161,11 @@ private extension PokemonDetailView {
                 print(error)
                 
             }).disposed(by: self.disposeBag)
+    }
+    
+    func addImage(id: Int) {
+        guard let url = URL(string: APIEndpoint.pokemonImageURL(id: id).urlString) else { return }
+        self.imageView.kf.setImage(with: url)
     }
 }
 

--- a/PokeDex/PokeDex/View/MainView/PokemonCell.swift
+++ b/PokeDex/PokeDex/View/MainView/PokemonCell.swift
@@ -35,6 +35,8 @@ final class PokemonCell: UICollectionViewCell {
         self.imageView.image = nil
     }
     
+    /// 셀의 이미지를 세팅하는 메소드
+    /// - Parameter id: 포켓몬의 ID
     func addImage(_ id: Int) {
         guard let url = URL(string: APIEndpoint.pokemonImageURL(id: id).urlString) else { return }
         self.imageView.kf.setImage(with: url)

--- a/PokeDex/PokeDex/View/MainView/PokemonCell.swift
+++ b/PokeDex/PokeDex/View/MainView/PokemonCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import Kingfisher
 
 // 메인뷰의 컬렉션뷰 커스텀 셀
 final class PokemonCell: UICollectionViewCell {
@@ -34,8 +35,9 @@ final class PokemonCell: UICollectionViewCell {
         self.imageView.image = nil
     }
     
-    func addImage(_ image: UIImage?) {
-        self.imageView.image = image
+    func addImage(_ id: Int) {
+        guard let url = URL(string: APIEndpoint.pokemonImageURL(id: id).urlString) else { return }
+        self.imageView.kf.setImage(with: url)
     }
 }
  

--- a/PokeDex/PokeDex/View/MainView/PokemonCollectionView.swift
+++ b/PokeDex/PokeDex/View/MainView/PokemonCollectionView.swift
@@ -18,7 +18,7 @@ final class PokemonCollectionView: UIView {
     
     private var didFeched: Bool = true // 현재 데이터를 불러오는 중인지 확인
     
-    private var pokemonImageList: [(image: UIImage,id: Int)] = []
+    private var pokemonList: [PokemonData] = []
     
     private lazy var collectionView: UICollectionView = {
         let cv = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
@@ -113,20 +113,21 @@ private extension PokemonCollectionView {
     
     /// 데이터 바인딩 메소드
     func bind() {
-        self.viewModel.pokemonImages
+        self.viewModel.pokemonList
             .withUnretained(self)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { owner, data in
                 
-                owner.pokemonImageList += data
-                owner.pokemonImageList.sort(by: { $0.id < $1.id })
+                owner.pokemonList += data
                 
                 owner.collectionView.reloadData()
                 owner.didFeched = false
                 owner.dataFetched()
                 
-            }, onError: { error in
+            }, onError: { [weak self] error in
                 print("Error: \(error)")
+                self?.didFeched = false
+                self?.dataFetched()
                 
             }).disposed(by: self.disposeBag)
     }
@@ -141,7 +142,7 @@ extension PokemonCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
         let detailView = PokemonDetailView(
-            image: self.pokemonImageList[indexPath.item].image,
+            image: UIImage(),
             model: DetailViewModel(pokemonManager: PokemonManager(), id: indexPath.item + 1)
         )
         
@@ -171,7 +172,7 @@ extension PokemonCollectionView: UICollectionViewDataSource {
     
     // 컬렉션뷰 아이템 수를 설정하는 메소드
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return self.pokemonImageList.count
+        return self.pokemonList.count
     }
     
     // 컬렉션뷰의 아이템을 설정하는 메소드
@@ -180,7 +181,7 @@ extension PokemonCollectionView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         
-        cell.addImage(self.pokemonImageList[indexPath.item].image)
+        cell.addImage(indexPath.item + 1)
         
         return cell
     }

--- a/PokeDex/PokeDex/View/MainView/PokemonCollectionView.swift
+++ b/PokeDex/PokeDex/View/MainView/PokemonCollectionView.swift
@@ -142,7 +142,7 @@ extension PokemonCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
         let detailView = PokemonDetailView(
-            image: UIImage(),
+            id: indexPath.item + 1,
             model: DetailViewModel(pokemonManager: PokemonManager(), id: indexPath.item + 1)
         )
         

--- a/PokeDex/PokeDex/View/MainView/PokemonCollectionView.swift
+++ b/PokeDex/PokeDex/View/MainView/PokemonCollectionView.swift
@@ -159,10 +159,10 @@ extension PokemonCollectionView: UICollectionViewDelegate {
         let threshold = visibleHeight - totalHeight
         
         if currentOffset >= threshold && !self.didFeched {
+            guard self.viewModel.getCurrentOffset() else { return }
             self.viewModel.reload()
             self.didFeched = true
             self.dataFetched()
-            self.layoutIfNeeded()
         }
     }
 }

--- a/PokeDex/PokeDex/View/MainView/PokemonCollectionView.swift
+++ b/PokeDex/PokeDex/View/MainView/PokemonCollectionView.swift
@@ -8,6 +8,7 @@
 import UIKit
 import SnapKit
 import RxSwift
+import RxCocoa
 
 // 포켓몬 도감 리스트를 보여주는 뷰
 final class PokemonCollectionView: UIView {
@@ -22,7 +23,6 @@ final class PokemonCollectionView: UIView {
     
     private lazy var collectionView: UICollectionView = {
         let cv = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
-        cv.delegate = self
         cv.dataSource = self
         cv.backgroundColor = .clear
         cv.showsVerticalScrollIndicator = false
@@ -75,7 +75,6 @@ private extension PokemonCollectionView {
     func configure() {
         self.backgroundColor = UIColor.personalDark
         [self.collectionView,
-//         self.blockingView,
          self.activityIndicator].forEach { self.addSubview($0) }
     }
     
@@ -113,6 +112,13 @@ private extension PokemonCollectionView {
     
     /// 데이터 바인딩 메소드
     func bind() {
+        bindPokemonList()
+        bindSelectCell()
+        bindDidScroll()
+    }
+    
+    /// 포켓몬 리스트를 바인딩하는 메소드
+    func bindPokemonList() {
         self.viewModel.pokemonList
             .withUnretained(self)
             .observe(on: MainScheduler.instance)
@@ -132,39 +138,54 @@ private extension PokemonCollectionView {
             }).disposed(by: self.disposeBag)
     }
     
-}
-
-// MARK: - PokemonCollectionView CollectionView Delegate Method
-extension PokemonCollectionView: UICollectionViewDelegate {
-    
-    // 셀이 선택되었을 때 액션 구현
-    // 선택된 셀의 포켓몬 정보를 확인할 수 있도록 네비게이션 구현
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
-        let detailView = PokemonDetailView(
-            id: indexPath.item + 1,
-            model: DetailViewModel(pokemonManager: PokemonManager(), id: indexPath.item + 1)
-        )
-        
-        guard let view = self.window?.rootViewController as? UINavigationController else { return }
-        view.pushViewController(DetaileViewController(detailView: detailView), animated: true)
+    /// 컬렉션뷰의 아이템 선택에 대해 바인딩하는 메소드
+    func bindSelectCell() {
+        self.collectionView.rx.itemSelected
+            .withUnretained(self)
+            .subscribe(on: MainScheduler.instance)
+            .subscribe(onNext: { owner, indexPath in
+                
+                let detailView = PokemonDetailView(
+                    id: indexPath.item + 1,
+                    model: DetailViewModel(pokemonManager: PokemonManager(), id: indexPath.item + 1)
+                )
+                
+                guard let view = owner.window?.rootViewController as? UINavigationController else { return }
+                view.pushViewController(DetaileViewController(detailView: detailView), animated: true)
+                
+            }, onError: { error in
+                
+                print(error)
+                
+            }).disposed(by: self.disposeBag)
     }
     
-    // 스크롤이 진행 중일 때 액션
-    // 현재 스크롤 위치를 확인하여 스크롤이 최하단에 있는 경우 데이터를 더 불러온다.
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let currentOffset = scrollView.contentOffset.y
-        let visibleHeight = scrollView.contentSize.height
-        let totalHeight = scrollView.frame.height
-        let threshold = visibleHeight - totalHeight
-        
-        if currentOffset >= threshold && !self.didFeched {
-            guard self.viewModel.getCurrentOffset() else { return }
-            self.viewModel.reload()
-            self.didFeched = true
-            self.dataFetched()
-        }
+    /// 컬렉션뷰의 스크롤에 대해 바인딩하는 메소드
+    func bindDidScroll() {
+        self.collectionView.rx.didScroll
+            .withUnretained(self)
+            .subscribe(on: MainScheduler.instance)
+            .subscribe(onNext: { owner, scrollView in
+                
+                let currentOffset = owner.collectionView.contentOffset.y
+                let visibleHeight = owner.collectionView.contentSize.height
+                let totalHeight = owner.frame.height
+                let threshold = visibleHeight - totalHeight + 100
+                
+                if currentOffset > threshold && !owner.didFeched {
+                    guard self.viewModel.getCurrentOffset() else { return }
+                    owner.viewModel.reload()
+                    owner.didFeched = true
+                    owner.dataFetched()
+                }
+                
+            }, onError: { error in
+                
+                print(error)
+                
+            }).disposed(by: self.disposeBag)
     }
+    
 }
 
 // MARK: - PokemonCollectionView CollectionView DataSource Method

--- a/PokeDex/PokeDex/View/SearchView/SearchTableView.swift
+++ b/PokeDex/PokeDex/View/SearchView/SearchTableView.swift
@@ -8,14 +8,14 @@
 import UIKit
 import SnapKit
 
+// 검색 결과 테이블 뷰
 final class SearchTableView: UIView {
     
-    private let tableView = UITableView()
+    let tableView = UITableView()
     
-    var searchPokemonList: [(id: Int, name: String)] = []
-    
-    var selectedCell: ((Int) -> Void)?
-    
+    var searchPokemonList: [(id: Int, name: String)] = [] // 검색결과를 담는 배열
+        
+    // MARK: - SearchTableView Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -28,6 +28,7 @@ final class SearchTableView: UIView {
         setupUI()
     }
     
+    /// 검색 결과를 다시 불러오는 메소드
     func reloadData() {
         self.searchPokemonList.sort(by: { $0.id < $1.id })
         
@@ -36,6 +37,7 @@ final class SearchTableView: UIView {
         }
     }
     
+    /// 검색 결과를 초기화 하는 메소드
     func resetData() {
         self.searchPokemonList.removeAll()
         self.tableView.reloadData()
@@ -43,19 +45,23 @@ final class SearchTableView: UIView {
     
 }
 
+// MARK: - SearchTableView UI Setting Method
 private extension SearchTableView {
     
+    /// 모든 UI를 세팅하는 메소드
     func setupUI() {
         configure()
         setupTableView()
         setupLayout()
     }
     
+    /// self에 대해 설정하는 메소드
     func configure() {
         self.backgroundColor = .clear
         self.addSubview(self.tableView)
     }
     
+    /// 테이블뷰를 세팅하는 메소드
     func setupTableView() {
         self.tableView.backgroundColor = .clear
         self.tableView.rowHeight = 50
@@ -63,10 +69,10 @@ private extension SearchTableView {
         self.tableView.showsVerticalScrollIndicator = false
         self.tableView.showsHorizontalScrollIndicator = false
         self.tableView.dataSource = self
-        self.tableView.delegate = self
         self.tableView.register(SearchTableViewCell.self, forCellReuseIdentifier: SearchTableViewCell.id)
     }
     
+    /// 모든 레이아웃을 설정하는 메소드
     func setupLayout() {
         self.tableView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -75,19 +81,15 @@ private extension SearchTableView {
     
 }
 
-extension SearchTableView: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let data = self.searchPokemonList[indexPath.row]
-        self.selectedCell?(data.id)
-    }
-}
-
+// MARK: - SearchTableView UITableViewDataSource Method
 extension SearchTableView: UITableViewDataSource {
     
+    // 셀의 수를 설정하는 메소드
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return self.searchPokemonList.count
     }
     
+    // 셀을 설정하는 메소드
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: SearchTableViewCell.id, for: indexPath) as? SearchTableViewCell else {
             return UITableViewCell()

--- a/PokeDex/PokeDex/View/SearchView/SearchTableViewCell.swift
+++ b/PokeDex/PokeDex/View/SearchView/SearchTableViewCell.swift
@@ -8,13 +8,15 @@
 import UIKit
 import SnapKit
 
+// 테이블뷰 커스텀 셀
 final class SearchTableViewCell: UITableViewCell {
     
-    static let id: String = "SearchTableViewCell"
+    static let id: String = "SearchTableViewCell" // 셀 고유 아이디
     
     private let numberLabel = UILabel()
     private let nameLabel = UILabel()
     
+    // MARK: - SearchTableViewCell Initializer
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
@@ -27,20 +29,27 @@ final class SearchTableViewCell: UITableViewCell {
         setupUI()
     }
     
+    /// 레이블의 텍스트를 설정하는 메소드
+    /// - Parameters:
+    ///   - id: 포켓몬 ID
+    ///   - name: 포켓몬 이름
     func configLabel(id: Int, name: String) {
         self.numberLabel.text = "No.\(id)"
         self.nameLabel.text = name
     }
 }
 
+// MARK: - SearchTableViewCell UI Setting Method
 private extension SearchTableViewCell {
     
+    /// 모든 UI를 세팅하는 메소드
     func setupUI() {
         configure()
         setupLabel()
         setupLayout()
     }
     
+    /// self에 대해 설정하는 메소드
     func configure() {
         self.backgroundColor = .personalDark
         self.layer.cornerRadius = 15
@@ -51,6 +60,7 @@ private extension SearchTableViewCell {
         }
     }
     
+    /// 레이블을 세팅하는 메소드
     func setupLabel() {
         [self.numberLabel, self.nameLabel].forEach {
             $0.textColor = .white
@@ -62,6 +72,7 @@ private extension SearchTableViewCell {
         self.nameLabel.textAlignment = .right
     }
     
+    /// 모든 레이아웃을 세팅하는 메소드
     func setupLayout() {
         self.numberLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()

--- a/PokeDex/PokeDex/View/SearchView/SearchView.swift
+++ b/PokeDex/PokeDex/View/SearchView/SearchView.swift
@@ -110,7 +110,7 @@ private extension SearchView {
     func setupClosure() {
         DispatchQueue.main.async {
             self.searchResultsTableView.selectedCell = {
-                let image = self.viewModel.addImage(id: $0)
+                let image = UIImage()
                 
                 let detailView = PokemonDetailView(
                     image: image,

--- a/PokeDex/PokeDex/View/SearchView/SearchView.swift
+++ b/PokeDex/PokeDex/View/SearchView/SearchView.swift
@@ -109,12 +109,12 @@ private extension SearchView {
     
     func setupClosure() {
         DispatchQueue.main.async {
-            self.searchResultsTableView.selectedCell = {
-                let image = UIImage()
+            self.searchResultsTableView.selectedCell = { [weak self] id in
+                guard let self else { return }
                 
                 let detailView = PokemonDetailView(
-                    image: image,
-                    model: DetailViewModel(pokemonManager: PokemonManager(), id: $0)
+                    id: id,
+                    model: DetailViewModel(pokemonManager: PokemonManager(), id: id)
                 )
                 
                 guard let view = self.window?.rootViewController as? UINavigationController else { return }

--- a/PokeDex/PokeDex/View/SearchView/SearchView.swift
+++ b/PokeDex/PokeDex/View/SearchView/SearchView.swift
@@ -158,9 +158,9 @@ private extension SearchView {
     func bindTableViewSelect() {
         self.searchResultsTableView.tableView.rx.itemSelected
             .withUnretained(self)
-            .subscribe(onNext: { owner, data in
+            .subscribe(onNext: { owner, indexPath in
                 
-                let id = owner.searchResultsTableView.searchPokemonList[data.row].id
+                let id = owner.searchResultsTableView.searchPokemonList[indexPath.row].id
                 owner.presentDetailView(id: id)
                 
             }, onError: { error in

--- a/PokeDex/PokeDex/View/SearchView/SearchView.swift
+++ b/PokeDex/PokeDex/View/SearchView/SearchView.swift
@@ -15,6 +15,8 @@ final class SearchView: UIView {
     
     private let searchResultsTableView = SearchTableView()
     
+    private let resultLabel = UILabel()
+    
     private let viewModel = SearchViewModel(pokemonManager: PokemonManager())
     
     private let disposeBag = DisposeBag()
@@ -37,16 +39,19 @@ private extension SearchView {
     func setupUI() {
         configure()
         setupSearchBar()
+        setupResultLabel()
         setupLayout()
         addAction()
         bind()
         setupClosure()
+        changeSearchResult()
     }
     
     func configure() {
         self.backgroundColor = .clear
         [self.searchBar,
-         self.searchResultsTableView
+         self.searchResultsTableView,
+         self.resultLabel
         ].forEach {
             self.addSubview($0)
         }
@@ -65,6 +70,23 @@ private extension SearchView {
         self.searchBar.autocapitalizationType = .none
     }
     
+    func setupResultLabel() {
+        self.resultLabel.text = "검색 결과가 없습니다"
+        self.resultLabel.textColor = .personalDark
+        self.resultLabel.numberOfLines = 1
+        self.resultLabel.textAlignment = .center
+        self.resultLabel.font = UIFont.boldSystemFont(ofSize: 30)
+    }
+    
+    func changeSearchResult() {
+        switch self.searchResultsTableView.searchPokemonList.isEmpty {
+        case true:
+            self.resultLabel.isHidden = false
+        case false:
+            self.resultLabel.isHidden = true
+        }
+    }
+    
     func setupLayout() {
         self.searchBar.snp.makeConstraints {
             $0.top.equalToSuperview().offset(10)
@@ -75,6 +97,10 @@ private extension SearchView {
         self.searchResultsTableView.snp.makeConstraints {
             $0.top.equalTo(self.searchBar.snp.bottom).offset(20)
             $0.trailing.leading.bottom.equalToSuperview().inset(10)
+        }
+        
+        self.resultLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
         }
     }
     
@@ -87,9 +113,11 @@ private extension SearchView {
         
         if text.count <= 0 {
             self.searchResultsTableView.resetData()
+            changeSearchResult()
         } else {
             self.searchResultsTableView.resetData()
             self.viewModel.search(text: text)
+            changeSearchResult()
         }
     }
     

--- a/PokeDex/PokeDex/View/SearchView/SearchView.swift
+++ b/PokeDex/PokeDex/View/SearchView/SearchView.swift
@@ -94,8 +94,8 @@ private extension SearchView {
     
     func bind() {
         self.viewModel.searchPokemonList
-            .subscribe(on: MainScheduler.instance)
             .withUnretained(self)
+            .subscribe(on: MainScheduler.instance)
             .subscribe(onNext: { owner, data in
                 
                 owner.searchResultsTableView.searchPokemonList = data

--- a/PokeDex/PokeDex/View/SearchView/SearchView.swift
+++ b/PokeDex/PokeDex/View/SearchView/SearchView.swift
@@ -88,6 +88,7 @@ private extension SearchView {
         if text.count <= 0 {
             self.searchResultsTableView.resetData()
         } else {
+            self.searchResultsTableView.resetData()
             self.viewModel.search(text: text)
         }
     }

--- a/PokeDex/PokeDex/View/SearchView/SearchViewController.swift
+++ b/PokeDex/PokeDex/View/SearchView/SearchViewController.swift
@@ -8,27 +8,36 @@
 import UIKit
 import SnapKit
 
+// 검색뷰 컨트롤러
 final class SearchViewController: UIViewController {
     
-    private let searchView = PokeDexView(view: SearchView())
+    private let searchView = PokeDexView(view: SearchView()) // 검색 화면
     
+    // MARK: - SearchViewController LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
         setupUI()
     }
+}
+
+// MARK: - SearchViewController UI Setting Method
+private extension SearchViewController {
     
-    private func setupUI() {
+    /// 모든 UI를 세팅하는 메소드
+    func setupUI() {
         configure()
         setupLayout()
     }
     
-    private func configure() {
+    /// self에 대한 설정을 하는 메소드
+    func configure() {
         self.view.backgroundColor = .personal
         self.view.addSubview(self.searchView)
     }
     
-    private func setupLayout() {
+    /// 모든 레이아웃을 설정하는 메소드
+    func setupLayout() {
         self.searchView.snp.makeConstraints {
             $0.edges.equalTo(self.view.safeAreaLayoutGuide)
         }

--- a/PokeDex/PokeDex/View/TabBar/MainTabBarCell.swift
+++ b/PokeDex/PokeDex/View/TabBar/MainTabBarCell.swift
@@ -8,12 +8,14 @@
 import UIKit
 import SnapKit
 
+// 탭 바 셀
 final class MainTabBarCell: UICollectionViewCell {
     
-    static let id: String = "MainTabBarCell"
+    static let id: String = "MainTabBarCell" // 셀 고유 ID
     
     private let tabLabel = UILabel()
     
+    // MARK: - MainTabBarCell Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -26,6 +28,8 @@ final class MainTabBarCell: UICollectionViewCell {
         setupUI()
     }
     
+    // 터치영역 설정
+    // 레이블 외의 영역을 터치하면 터치 이벤트가 발생하지 않음
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         if self.tabLabel.frame.contains(point) {
             return super.hitTest(point, with: event)
@@ -34,32 +38,44 @@ final class MainTabBarCell: UICollectionViewCell {
         }
     }
     
-    private func setupUI() {
+    /// 레이블의 텍스트를 설정하는 메소드
+    /// - Parameter title: 레이블 텍스트
+    func configLabel(title: String) {
+        self.tabLabel.text = title
+    }
+}
+
+// MARK: - MainTabBarCell UI Setting Method
+private extension MainTabBarCell {
+    
+    /// 모든 UI를 세팅하는 메소드
+    func setupUI() {
         configure()
         setupLabel()
         setupLayout()
     }
     
-    private func configure() {
+    /// self를 설정하는 메소드
+    func configure() {
         self.backgroundColor = .clear
         self.clipsToBounds = true
         self.contentView.addSubview(self.tabLabel)
     }
     
-    private func setupLabel() {
+    /// 레이블을 세팅하는 메소드
+    func setupLabel() {
         self.tabLabel.font = UIFont.systemFont(ofSize: 25, weight: .regular)
         self.tabLabel.textColor = .personalDark
         self.tabLabel.numberOfLines = 1
         self.tabLabel.textAlignment = .center
     }
     
-    private func setupLayout() {
+    /// 모든 레이아웃을 세팅하는 메소드
+    func setupLayout() {
         self.tabLabel.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
     }
     
-    func configLabel(title: String) {
-        self.tabLabel.text = title
-    }
+    
 }

--- a/PokeDex/PokeDex/View/TabBar/MainTabBarController.swift
+++ b/PokeDex/PokeDex/View/TabBar/MainTabBarController.swift
@@ -9,14 +9,18 @@ import UIKit
 import SnapKit
 import RxSwift
 
+// 탭 바 컨트롤러
 final class MainTabBarController: UIViewController {
     
     private let mainTabBar = MainTabBarView()
     private let disposeBag = DisposeBag()
     
-    private let viewControllers: [UIViewController]
-    private var currentVC: UIViewController?
+    private let viewControllers: [UIViewController] // 탭바가 관리할 뷰 컨트롤러 목록
+    private var currentVC: UIViewController? // 현재 뷰 컨트롤러
     
+    // MARK: - MainTabBarController Initializer
+    
+    // 초기화시 탭 바가 관리할 뷰 컨트롤러 목록을 파라미터로 받음
     init(viewControllers: [UIViewController]) {
         self.viewControllers = viewControllers
         
@@ -27,6 +31,7 @@ final class MainTabBarController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - MainTabBarController LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -34,8 +39,10 @@ final class MainTabBarController: UIViewController {
     }
 }
 
+// MARK: - MainTabBarController UI Setting Method
 private extension MainTabBarController {
     
+    /// 모든 UI를 세팅하는 메소드
     func setupUI() {
         configure()
         setupLayout()
@@ -43,11 +50,13 @@ private extension MainTabBarController {
         bind()
     }
     
+    /// self에 대해 설정하는 메소드
     func configure() {
         self.view.backgroundColor = .personal
         self.view.addSubview(self.mainTabBar)
     }
     
+    /// 모든 레이아웃을 설정하는 메소드
     func setupLayout() {
         self.mainTabBar.snp.makeConstraints {
             $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
@@ -56,6 +65,8 @@ private extension MainTabBarController {
         }
     }
     
+    /// 현재 뷰 컨트롤러를 바꾸는 메소드
+    /// - Parameter index: 페이지 인덱스
     func displayViewController(_ index: Int) {
         if let currentVC = self.currentVC {
             currentVC.view.removeFromSuperview()
@@ -75,6 +86,7 @@ private extension MainTabBarController {
         self.currentVC = selectedVC
     }
     
+    /// 데이터 바인딩 메소드
     func bind() {
         self.mainTabBar.viewModel.pageIndex
             .withUnretained(self)

--- a/PokeDex/PokeDex/View/TabBar/MainTabBarView.swift
+++ b/PokeDex/PokeDex/View/TabBar/MainTabBarView.swift
@@ -7,19 +7,24 @@
 
 import UIKit
 import SnapKit
+import RxCocoa
+import RxSwift
 
+// 탭 바 아이템 스페이스
 enum TabBarItem: String, CaseIterable {
     case main = "도감"
     case search = "검색"
 }
 
+// 탭 바 뷰
 final class MainTabBarView: UIView {
         
-    let viewModel = TabBarViewModel()
+    let viewModel = TabBarViewModel() // 로직 및 데이터 바인딩 객체
+    
+    private let disposeBag = DisposeBag()
     
     private lazy var tabBarView: UICollectionView = {
         let cv = UICollectionView(frame: .zero, collectionViewLayout: self.layout)
-        cv.delegate = self
         cv.dataSource = self
         cv.backgroundColor = .clear
         cv.showsHorizontalScrollIndicator = false
@@ -39,8 +44,9 @@ final class MainTabBarView: UIView {
         return layout
     }()
     
-    private let effectView = SelectEffect()
+    private let effectView = SelectEffect() // 애니메이션 인디케이터
     
+    // MARK: - MainTabBarView Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -54,14 +60,18 @@ final class MainTabBarView: UIView {
     }
 }
 
+// MARK: - MainTabBarView UI Setting Method
 private extension MainTabBarView {
     
+    /// 모든 UI를 세팅하는 메소드
     func setupUI() {
         configure()
         setupTabBarViewLayout()
         setupEffectView()
+        bind()
     }
     
+    /// self에 대해 설정하는 메소드
     func configure() {
         self.backgroundColor = .personal
         self.layer.shadowColor = UIColor.black.cgColor
@@ -72,18 +82,39 @@ private extension MainTabBarView {
         [self.tabBarView, self.effectView].forEach { self.addSubview($0) }
     }
     
+    /// 모든 레이아웃을 세팅하는 메소드
     func setupTabBarViewLayout() {
         self.tabBarView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
     
+    /// 인디케이터를 세팅하는 메소드
     func setupEffectView() {
         self.effectView.configLabel(title: TabBarItem.main.rawValue)
         let constraintX: CGFloat = (UIScreen.main.bounds.width / 2) / 2 - 75
         self.effectView.frame = .init(x: constraintX, y: 20, width: 150, height: 60)
     }
     
+    /// 데이터 바인딩 메소드
+    func bind() {
+        self.tabBarView.rx.itemSelected
+            .subscribe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] indexPath in
+                
+                self?.viewModel.changePageIndex(indexPath.item)
+                self?.moveEffectView(TabBarItem.allCases[indexPath.item])
+                
+            }, onError: { error in
+                
+                print(error)
+                
+            }).disposed(by: self.disposeBag)
+            
+    }
+    
+    /// 인디케이터의 애니메이션을 설정하는 메소드
+    /// - Parameter title: 인디케이터의 레이블 값
     func moveEffectView(_ title: TabBarItem) {
         self.effectView.configLabel(title: title.rawValue)
         
@@ -99,18 +130,15 @@ private extension MainTabBarView {
     
 }
 
-extension MainTabBarView: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        self.viewModel.changePageIndex(indexPath.item)
-        moveEffectView(TabBarItem.allCases[indexPath.item])
-    }
-}
-
+// MARK: - MainTabBarView UICollectionViewDataSource Method
 extension MainTabBarView: UICollectionViewDataSource {
+    
+    // 셀 수량 설정 메소드
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return TabBarItem.allCases.count
     }
     
+    // 셀 설정 메소드
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainTabBarCell.id, for: indexPath) as? MainTabBarCell else {
             return UICollectionViewCell()

--- a/PokeDex/PokeDex/View/TabBar/MainTabBarView.swift
+++ b/PokeDex/PokeDex/View/TabBar/MainTabBarView.swift
@@ -44,7 +44,7 @@ final class MainTabBarView: UIView {
         return layout
     }()
     
-    private let effectView = SelectEffect() // 애니메이션 인디케이터
+    private let effectView = TabBarIndicator() // 애니메이션 인디케이터
     
     // MARK: - MainTabBarView Initializer
     override init(frame: CGRect) {

--- a/PokeDex/PokeDex/View/TabBar/TabBarIndicator.swift
+++ b/PokeDex/PokeDex/View/TabBar/TabBarIndicator.swift
@@ -8,10 +8,12 @@
 import UIKit
 import SnapKit
 
-final class SelectEffect: UIView {
+// 탭 바의 인디케이터
+final class TabBarIndicator: UIView {
     
     private let titleLabel = UILabel()
     
+    // MARK: - TabBarIndicator Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -24,26 +26,32 @@ final class SelectEffect: UIView {
         setupUI()
     }
     
+    /// 인디케이터 레이블을 설정하는 메소드
+    /// - Parameter title: 레이블 텍스트
     func configLabel(title: String) {
         self.titleLabel.text = title
     }
     
 }
 
-private extension SelectEffect {
+// MARK: - TabBarIndicator UI Setting Method
+private extension TabBarIndicator {
     
+    /// 모든 UI를 세팅하는 메소드
     func setupUI() {
         configure()
         setupLabel()
         setupLayout()
     }
     
+    /// self에 대한 설정을 하는 메소드
     func configure() {
         self.backgroundColor = .personalDark
         self.layer.cornerRadius = 30
         self.addSubview(self.titleLabel)
     }
     
+    /// 레이블을 세팅하는 메소드
     func setupLabel() {
         self.titleLabel.font = UIFont.boldSystemFont(ofSize: 30)
         self.titleLabel.textAlignment = .center
@@ -52,6 +60,7 @@ private extension SelectEffect {
         self.titleLabel.backgroundColor = .clear
     }
     
+    /// 레이아웃을 세팅하는 메소드
     func setupLayout() {
         self.titleLabel.snp.makeConstraints {
             $0.edges.equalToSuperview()

--- a/PokeDex/PokeDex/View/ViewController.swift
+++ b/PokeDex/PokeDex/View/ViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import SnapKit
 
+// 루트 뷰
 final class ViewController: UIViewController {
     
     private lazy var mainVC = MainTabBarController(viewControllers: [
@@ -15,6 +16,7 @@ final class ViewController: UIViewController {
         SearchViewController()
     ])
     
+    // MARK: - ViewController LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/PokeDex/PokeDex/ViewModel/MainViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/MainViewModel.swift
@@ -11,8 +11,9 @@ import RxSwift
 // 메인 뷰의 로직을 담당하는 모델
 final class MainViewModel {
     private let pokemonManager: PokemonServiceProtocol // 데이터 패치를 담당하는 인스턴스
-    private var limit: Int = 30
+    private var limit: Int = 25
     private var offset: Int = 0
+    private let pokemons: Int = 1025
     private var existentPokemons: Set<Int> = [] // 가져온 데이터의 중복 방지를 위한 데이터 타입
     private var nextURL: String = "" // 다음 데이터 리스트의 API 링크를 담을 프로퍼티
     
@@ -33,7 +34,11 @@ final class MainViewModel {
     
     /// 스크롤을 모두 완료하면 새로운 데이터 리스트를 불러오는 메소드
     func reload() {
-        fetchPokemonData(urlType: .customURL(url: self.nextURL))
+        fetchPokemonData(urlType: .pokemonList(limit: self.limit, offset: self.offset))
+    }
+    
+    func getCurrentOffset() -> Bool {
+        return self.offset <= self.pokemons
     }
 }
 
@@ -50,8 +55,8 @@ private extension MainViewModel {
         .subscribe(onSuccess: { [weak self] data in
             guard let self else { return }
             
-            self.nextURL = data.next
             self.pokemonList.onNext(data.results)
+            self.offset += self.limit
             
         }, onFailure: { [weak self] error in
             self?.pokemonList.onError(error)

--- a/PokeDex/PokeDex/ViewModel/MainViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/MainViewModel.swift
@@ -11,10 +11,15 @@ import RxSwift
 // 메인 뷰의 로직을 담당하는 모델
 final class MainViewModel {
     private let pokemonManager: PokemonServiceProtocol // 데이터 패치를 담당하는 인스턴스
-    private var limit: Int = 25
-    private var offset: Int = 0
-    private let pokemons: Int = 1025
+    
+    private var limit: Int = 25 // 한 번에 불러올 포켓몬 데이터 수
+    
+    private var offset: Int = 0 // 몇 번째 포켓몬부터 불러올 것인지 선택
+    
+    private let pokemons: Int = 1025 // 최대 포켓몬 수
+    
     private var existentPokemons: Set<Int> = [] // 가져온 데이터의 중복 방지를 위한 데이터 타입
+    
     private var nextURL: String = "" // 다음 데이터 리스트의 API 링크를 담을 프로퍼티
     
     let disposeBag = DisposeBag()
@@ -37,6 +42,8 @@ final class MainViewModel {
         fetchPokemonData(urlType: .pokemonList(limit: self.limit, offset: self.offset))
     }
     
+    /// 현재 포켓몬 도감 번호가 최대 포켓몬 수 이하인지 확인하는 메소드
+    /// - Returns: 최대 포켓몬 수보다 작을 경우 true, 클 경우 false
     func getCurrentOffset() -> Bool {
         return self.offset <= self.pokemons
     }
@@ -56,7 +63,7 @@ private extension MainViewModel {
             guard let self else { return }
             
             self.pokemonList.onNext(data.results)
-            self.offset += self.limit
+            self.offset += self.limit // 다시 메소드를 호출했을 때 다음 포켓몬 리스트를 불러오기 위한 로직
             
         }, onFailure: { [weak self] error in
             self?.pokemonList.onError(error)

--- a/PokeDex/PokeDex/ViewModel/MainViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/MainViewModel.swift
@@ -17,11 +17,7 @@ final class MainViewModel {
     private var offset: Int = 0 // 몇 번째 포켓몬부터 불러올 것인지 선택
     
     private let pokemons: Int = 1025 // 최대 포켓몬 수
-    
-    private var existentPokemons: Set<Int> = [] // 가져온 데이터의 중복 방지를 위한 데이터 타입
-    
-    private var nextURL: String = "" // 다음 데이터 리스트의 API 링크를 담을 프로퍼티
-    
+            
     let disposeBag = DisposeBag()
     
     let pokemonList = PublishSubject<[PokemonData]>() // 데이터 바인딩 객체

--- a/PokeDex/PokeDex/ViewModel/PokemonServiceProtocol.swift
+++ b/PokeDex/PokeDex/ViewModel/PokemonServiceProtocol.swift
@@ -11,7 +11,6 @@ import RxSwift
 // 뷰 모델이 공통으로 사용할 메소드를 정의하는 프로토콜
 protocol PokemonServiceProtocol {
     func fetchPokemonData<T: Decodable>(urlType: APIEndpoint, modelType: T.Type) -> Single<T>
-    func fetchPokemonDetails(_ datas: [PokemonData]) -> Single<[PokemonDetailDataModel]>
 }
 
 // 뷰 모델이 공통으로 사용할 메소드를 구현하는 객체
@@ -29,19 +28,5 @@ final class PokemonManager: PokemonServiceProtocol {
         }
         
         return NetworkManager.shared.fetch(url: url)
-    }
-    
-    /// 포켓몬 데이터 리스트를 포켓몬의 디테일 데이터 리스트로 변환해주는 메소드
-    /// - Parameter datas: 포켓몬 데이터 리스트
-    /// - Returns: 포켓몬의 디테일 데이터 리스트를 가진 옵저버블 타입
-    func fetchPokemonDetails(_ datas: [PokemonData]) -> Single<[PokemonDetailDataModel]> {
-        return Observable.from(datas)
-            .flatMap { data -> Single<PokemonDetailDataModel> in
-                guard let url = URL(string: data.url) else {
-                    return Single.error(NetworkError.invalidURL)
-                }
-                return NetworkManager.shared.fetch(url: url)
-            }
-            .toArray()
     }
 }

--- a/PokeDex/PokeDex/ViewModel/SearchViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/SearchViewModel.swift
@@ -8,23 +8,44 @@
 import UIKit
 import RxSwift
 
+// 검색 뷰 모델
 final class SearchViewModel {
     typealias Names = (String, String)
     
-    private let pokemonManager: PokemonServiceProtocol
+    private let pokemonManager: PokemonServiceProtocol // 데이터 패치를 담당하는 인스턴스
     
     private let disposeBag = DisposeBag()
     
-    private var pokemonList: [PokemonData] = []
-        
-    let searchPokemonList = PublishSubject<[(Int, String)]>()
+    private var pokemonList: [PokemonData] = [] // 모든 포켓몬에 대한 정보가 담긴 배열
     
+    let searchPokemonList = PublishSubject<[(Int, String)]>() // 데이터 바인딩 객체
+    
+    // MARK: - SearchViewModel Initializer
+    
+    // 초기화시 파라미터로 PokemonServiceProtocol 타입의 값을 지정
+    // 파라미터 값을 이용하여 포켓몬 매니저 초기화
+    // 모든 포켓몬 데이터를 불러오는 메소드 실행(dataLoad)
     init(pokemonManager: PokemonServiceProtocol) {
         self.pokemonManager = pokemonManager
         dataLoad()
     }
     
-    private func dataLoad() {
+    /// 검색한 값과 관련있는 포켓몬 데이터를 이벤트로 방출하는 메소드
+    /// - Parameter text: 검색창 입력 값
+    func search(text: String) {
+        let list = containsSearchResult(text: text)
+        
+        guard list.count > 0 else { return }
+        
+        self.searchPokemonList.onNext(list)
+    }
+}
+
+// MARK: - SearchViewModel Private Method
+private extension SearchViewModel {
+    
+    /// 모든 포켓몬의 정보를 불러오는 메소드
+    func dataLoad() {
         self.pokemonManager.fetchPokemonData(urlType: .pokemonList(limit: 1025, offset: 0), modelType: PokemonDataModel.self)
             .observe(on: ConcurrentDispatchQueueScheduler(qos: .default))
             .subscribe(onSuccess: { [weak self] data in
@@ -39,47 +60,29 @@ final class SearchViewModel {
         
     }
     
-    func search(text: String) {
-        if let result = Int(text) {
-            var searchList: [(Int, String)] = []
-            
-            let list = self.pokemonList.enumerated().filter { index, _ in
-                (index + 1).contains(result)
-            }.map {
-                ($0.offset, $0.element)
-            }
-            
-            guard list.count > 0 else { return }
-            
-            searchList += addData(datas: list)
-            
-            self.searchPokemonList.onNext(searchList)
-            
-        } else {
-            var searchList: [(Int, String)] = []
-            
-            let enList = self.pokemonList.enumerated().filter { index, data in
-                data.name.contains(text.lowercased())
-            }.map {
-                ($0.offset, $0.element)
-            }
-            
-            let koList = self.pokemonList.enumerated().filter { index, data in
-                PokemonTranslator.getKoreanName(for: data.name).contains(text)
-            }.map {
-                ($0.offset, $0.element)
-            }
-            
-            guard enList.count > 0 || koList.count > 0 else { return }
-            
-            searchList += addData(datas: enList)
-            searchList += addData(datas: koList)
-         
-            self.searchPokemonList.onNext(searchList)
+    /// 입력된 값과 연관된 포켓몬 리스트를 반환하는 메소드
+    /// - Parameter text: 입력 값
+    /// - Returns: 포켓몬 ID, Name 배열
+    func containsSearchResult(text: String) -> [(Int, String)] {
+        var searchList: [(Int, String)] = []
+        
+        let list = self.pokemonList.enumerated().filter { index, data in
+            PokemonTranslator.getKoreanName(for: data.name).contains(text) ||
+            data.name.contains(text.lowercased()) ||
+            (index + 1).contains(Int(text) ?? -1)
+        }.map {
+            ($0.offset, $0.element)
         }
+        
+        searchList += addData(datas: list)
+        
+        return searchList
     }
     
-    private func addData(datas: [(Int, PokemonData)]) -> [(id: Int, name: String)] {
+    /// 포켓몬 데이터 배열을 ID, Name 배열로 반환하는 메소드
+    /// - Parameter datas: 포켓몬 ID와 포켓몬 데이터가 포함된 배열
+    /// - Returns: 포켓몬 ID와 포켓몬 이름을 담은 튜플 배열
+    func addData(datas: [(Int, PokemonData)]) -> [(id: Int, name: String)] {
         var result: [(Int, String)] = []
         
         datas.forEach { index, data in
@@ -93,7 +96,11 @@ final class SearchViewModel {
     }
 }
 
+// MARK: - Int Extension Method
 extension Int {
+    /// Int 타입끼리의 contains 메소드
+    /// - Parameter digit: 비교할 값
+    /// - Returns: digit이 self에 포함된 경우 true, 그렇지 않은 경우 false
     func contains(_ digit: Int) -> Bool {
         let number = String(self)
         let digitNumber = String(digit)

--- a/PokeDex/PokeDex/ViewModel/SearchViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/SearchViewModel.swift
@@ -45,10 +45,10 @@ final class SearchViewModel {
         
     }
     
-    func addImage(id: Int) -> UIImage {
-        guard let image = NetworkManager.shared.fetchImage(id: id) else { return UIImage() }
-        return image
-    }
+//    func addImage(id: Int) -> UIImage {
+//        guard let image = NetworkManager.shared.fetchImage(id: id) else { return UIImage() }
+//        return image
+//    }
     
     func search(text: String) {
         if let result = Int(text) {

--- a/PokeDex/PokeDex/ViewModel/TabBarViewModel.swift
+++ b/PokeDex/PokeDex/ViewModel/TabBarViewModel.swift
@@ -8,10 +8,13 @@
 import UIKit
 import RxCocoa
 
+// 탭바의 뷰 모델
 final class TabBarViewModel {
     
-    let pageIndex = PublishRelay<Int>()
+    let pageIndex = PublishRelay<Int>() // 현재 페이지 인덱스
     
+    /// 페이지 인덱스를 바꾸고 이벤트를 방출하는 메소드
+    /// - Parameter index: 페이지 인덱스
     func changePageIndex(_ index: Int) {
         self.pageIndex.accept(index)
     }


### PR DESCRIPTION
## ✨New Content✨
- kingfisher 라이브러리 추가
- 검색 결과가 없을 경우 보여줄 레이블 추가

## ♻️Change Point♻️
- 이미지 표현 방식 변경 -> kingfisher 메소드로 구현
- 네트워크 매니저의 `fetchPokemonImage` 메소드 삭제
- 컬렉션뷰 델리게이트 메소드 삭제 -> RxCocoa 데이터 바인딩으로 구현
- 포켓몬 서비스 객체의 `fetchPokemonDetails ` 메소드 삭제
- 포켓몬 ID 검출 방식 변경 -> 기존 API 통신을 통해 가져오던 것을 Index로 변경
- 문서 주석 추가
- 전체 구조 리팩토링

## 🚨Truble🚨
API 통신을 빠르게 마치기 위해서 PokemonDetailDataModel의 변환을 없애고 PokemonData의 배열만 가져오는 방식으로 변경하고 나니 포켓몬의 ID를 어떻게 가져오면 좋을지 어려웠다.

그러나 방식을 바꾸게 되며 포켓몬의 정보가 순서가 보장되며 들어오는 것을 확인하고 배열의 Index 값을 포켓몬의 ID로 활용할 수 있을 것 같다고 생각하였고, 이 방식을 적용하여 포켓몬 ID를 Index로 구현하는데 성공했다.

위의 방식 덕분에 다른 뷰에서의 데이터 로드 속도도 훨씬 빠르게 변경할 수 있었다.

```swift
/// 포켓몬 디테일 데이터를 불러오는 메소드
/// - Parameter urlType: URL 타입을 지정 -> 어떤 데이터를 불러올지 설정
func fetchPokemonData(urlType: APIEndpoint) {
        self.pokemonManager.fetchPokemonData(
            urlType: urlType,
            modelType: PokemonDataModel.self
        )
        .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .default))
        .subscribe(onSuccess: { [weak self] data in
            guard let self else { return }
            
            self.pokemonList.onNext(data.results)
            self.offset += self.limit // 다시 메소드를 호출했을 때 다음 포켓몬 리스트를 불러오기 위한 로직
            
        }, onFailure: { [weak self] error in
            self?.pokemonList.onError(error)
            
        }).disposed(by: self.disposeBag)
}
```

## 구현 영상

![무제2](https://github.com/user-attachments/assets/efc24e61-57a8-4ce5-8c81-9536c65b4e14)

close #32 